### PR TITLE
Added SBSRestartRenderServerAction

### DIFF
--- a/BaseBoard/BSAction.h
+++ b/BaseBoard/BSAction.h
@@ -1,0 +1,8 @@
+#import <Foundation/NSObject.h>
+
+#import <BaseBoard/BSXPCCoding.h>
+#import <BaseBoard/BSSettingDescriptionProvider.h>
+
+@interface BSAction : NSObject <BSXPCCoding, BSSettingDescriptionProvider>
+
+@end

--- a/BaseBoard/BSSettingDescriptionProvider.h
+++ b/BaseBoard/BSSettingDescriptionProvider.h
@@ -1,0 +1,9 @@
+
+#import <Foundation/NSObject.h>
+
+@protocol BSSettingDescriptionProvider <NSObject>
+@required
+-(id)keyDescriptionForSetting:(unsigned long long)arg1;
+-(id)valueDescriptionForFlag:(long long)arg1 object:(id)arg2 ofSetting:(unsigned long long)arg3;
+
+@end

--- a/BaseBoard/BSXPCCoding.h
+++ b/BaseBoard/BSXPCCoding.h
@@ -1,0 +1,7 @@
+#import <Foundation/NSObject.h>
+
+@protocol BSXPCCoding <NSObject>
+@required
+-(id)initWithXPCDictionary:(id)arg1;
+-(void)encodeWithXPCDictionary:(id)arg1;
+@end

--- a/SpringBoardServices/SBSRestartRenderServerAction.h
+++ b/SpringBoardServices/SBSRestartRenderServerAction.h
@@ -1,0 +1,11 @@
+#import <BaseBoard/BSAction.h>
+
+@class NSURL;
+
+@interface SBSRestartRenderServerAction : BSAction
+
+@property (nonatomic,readonly) NSURL *targetURL;
+
++ (instancetype)restartActionWithTargetRelaunchURL:(NSURL *)arg1 ;
+- (NSURL *)targetURL;
+@end


### PR DESCRIPTION
Added SBSRestartRenderServerAction and it's required superclasses and their protocols, should fix libcephei build failure on travis-ci integration