### PR TITLE
[BiometricKit] Complete Identity, Coordinates; improve manager

### DIFF
--- a/BiometricKit/BiometricKit.h
+++ b/BiometricKit/BiometricKit.h
@@ -1,13 +1,29 @@
 #import "BiometricKitDelegate.h"
+#import "BiometricKitIdentity.h"
 
+API_AVAILABLE(ios(7.0))
 @interface BiometricKit : NSObject
 
 + (BiometricKit *)manager;
 
 @property (nonatomic, assign) id<BiometricKitDelegate> delegate;
+@property (assign) BOOL inUse;
 
-- (NSArray *)identities:(id)object;
+// research on iOS 10.2 shows `options` supports { "BKFilterIdentity" : BiometricKitIdentity }
+- (NSArray<BiometricKitIdentity *> *)identities:(NSDictionary *)options;
 
-- (BOOL)isTouchIDCapable;
+- (float)getModulationRatio;
+
+- (BOOL)isTouchIDCapable API_AVAILABLE(ios(10.0));
+- (BOOL)isFingerOn API_AVAILABLE(ios(9.0));
+
+- (NSData *)getCalibrationDataInfo API_AVAILABLE(ios(9.0));
+- (NSData *)getSensorInfo API_AVAILABLE(ios(9.0));
+
+- (NSUUID *)getIdentitiesDatabaseUUIDForUser:(uid_t)user API_AVAILABLE(ios(10.0));
+- (NSData *)getIdentitiesDatabaseHashForUser:(uid_t)user API_AVAILABLE(ios(10.0));
+
+- (NSUUID *)getIdentitiesDatabaseUUID API_DEPRECATED("getIdentitiesDatabaseUUIDForUser:", ios(9.0, 10.0));
+- (NSData *)getIdentitiesDatabaseHash API_DEPRECATED("getIdentitiesDatabaseHashForUser:", ios(9.0, 10.0));
 
 @end

--- a/BiometricKit/BiometricKitEnrollProgressCoordinates.h
+++ b/BiometricKit/BiometricKitEnrollProgressCoordinates.h
@@ -1,0 +1,8 @@
+API_AVAILABLE(ios(7.0))
+@interface BiometricKitEnrollProgressCoordinates : NSObject
+
+@property (assign, nonatomic) double x;
+@property (assign, nonatomic) double y;
+@property (assign, nonatomic) double angle;
+
+@end

--- a/BiometricKit/BiometricKitEnrollProgressCoordinates.h
+++ b/BiometricKit/BiometricKitEnrollProgressCoordinates.h
@@ -1,8 +1,10 @@
+#import <CoreGraphics/CoreGraphics.h>
+
 API_AVAILABLE(ios(7.0))
 @interface BiometricKitEnrollProgressCoordinates : NSObject
 
-@property (assign, nonatomic) double x;
-@property (assign, nonatomic) double y;
-@property (assign, nonatomic) double angle;
+@property (assign, nonatomic) CGFloat x;
+@property (assign, nonatomic) CGFloat y;
+@property (assign, nonatomic) CGFloat angle;
 
 @end

--- a/BiometricKit/BiometricKitIdentity.h
+++ b/BiometricKit/BiometricKitIdentity.h
@@ -1,10 +1,19 @@
+API_AVAILABLE(ios(7.0))
 @interface BiometricKitIdentity : NSObject <NSSecureCoding, NSCopying>
 
-@property (nonatomic, retain) NSUUID * uuid;
-@property (nonatomic, assign) NSUInteger userID;
-@property (nonatomic, assign) NSInteger type;
-@property (nonatomic, assign) NSInteger attribute;
-@property (nonatomic, assign) NSInteger entity;
-@property (nonatomic, copy) NSString * name;
++ (instancetype)biometricKitIdentity;
+
+@property (nonatomic, retain) NSUUID *uuid;
+
+@property (nonatomic, assign) uid_t userID API_AVAILABLE(ios(10.0));
+@property (nonatomic, assign) int type;
+@property (nonatomic, assign) int attribute;
+@property (nonatomic, assign) int entity;
+
+@property (nonatomic, copy) NSString *name;
+@property (nonatomic, retain) NSDate *creationTime;
+
+@property (assign, nonatomic) NSInteger matchCount API_AVAILABLE(ios(8.0));
+@property (assign, nonatomic) NSInteger updateCount;
 
 @end


### PR DESCRIPTION
The types in `BiometricKitIdentity` were corrected to match the types provided by `NSCoder` 