### PR TITLE
Fix imports and declarations to allow compiling

### DIFF
--- a/BluetoothManager/RemoteDeviceManager.h
+++ b/BluetoothManager/RemoteDeviceManager.h
@@ -4,6 +4,8 @@ API_AVAILABLE(ios(8.0))
 @interface RemoteDeviceManager : NSObject
 
 - (void)disconnectDevice:(BluetoothDevice *)device;
+#if __has_include(<xpc/xpc.h>)
 - (void)sendMessage:(const char *)message args:(xpc_object_t)args;
+#endif
 
 @end

--- a/BulletinBoard/BBServer.h
+++ b/BulletinBoard/BBServer.h
@@ -1,7 +1,6 @@
 #import <Foundation/Foundation.h>
 
-@class BBBulletinRequest;
-@protocol BBDataProvider;
+@class BBBulletinRequest, BBDataProvider;
 
 @interface BBServer : NSObject
 

--- a/ChatKit/CKTranscriptManagementController.h
+++ b/ChatKit/CKTranscriptManagementController.h
@@ -1,5 +1,7 @@
 #import "CKViewController.h"
 
+@class CKConversation;
+
 @interface CKTranscriptManagementController : CKViewController
 
 - (instancetype)initWithConversation:(CKConversation *)conversation;

--- a/MobileGestalt/MobileGestalt.h
+++ b/MobileGestalt/MobileGestalt.h
@@ -197,6 +197,4 @@ static const CFStringRef kMGDeviceSupports3DMaps = CFSTR("DeviceSupports3DMaps")
 static const CFStringRef kMGDeviceSupports3DImagery = CFSTR("DeviceSupports3DImagery");
 static const CFStringRef kMGDeviceSupports1080p = CFSTR("DeviceSupports1080p");
 
-__END_DECLS
-
 #endif /* LIBMOBILEGESTALT_H_ */

--- a/MobileTimer/WorldClockCollectionCell.h
+++ b/MobileTimer/WorldClockCollectionCell.h
@@ -1,8 +1,8 @@
 // app
 
-@class WorldClockView;
+#import <UIKit/UICollectionViewCell.h>
 
-#import <UIkit/UICollectionViewCell.h>
+@class WorldClockView;
 
 @interface WorldClockCollectionCell : UICollectionViewCell
 

--- a/Preferences/PSSystemPolicyForApp.h
+++ b/Preferences/PSSystemPolicyForApp.h
@@ -6,6 +6,8 @@ typedef NS_OPTIONS(NSUInteger, PSSystemPolicyOptions) {
 	PSSystemPolicyOptionsPhotos = 1 << 5
 };
 
+@class PSSpecifier;
+
 @interface PSSystemPolicyForApp : NSObject
 
 - (instancetype)initWithBundleIdentifier:(NSString *)bundleIdentifier;

--- a/PreferencesUI/DevicePINControllerDelegate.h
+++ b/PreferencesUI/DevicePINControllerDelegate.h
@@ -1,0 +1,5 @@
+#import <Foundation/Foundation.h>
+
+@protocol DevicePINControllerDelegate <NSObject>
+
+@end

--- a/PreferencesUI/PSUIPrefsListController.h
+++ b/PreferencesUI/PSUIPrefsListController.h
@@ -1,5 +1,5 @@
 #import <Preferences/PSListController.h>
-#import <Preferences/DevicePINControllerDelegate.h>
+#import <PreferencesUI/DevicePINControllerDelegate.h>
 
 @interface PSUIPrefsListController : PSListController <DevicePINControllerDelegate>
 

--- a/QuartzCore/QuartzCore-Structs.h
+++ b/QuartzCore/QuartzCore-Structs.h
@@ -7,7 +7,6 @@
 
 #import <CoreGraphics/CoreGraphics.h>
 #import <QuartzCore/QuartzCore.h>
-#import <IOSurface/IOSurface.h>
 #include <pthread.h>
 
 typedef struct {

--- a/SpringBoard/SBAppSwitcherModel.h
+++ b/SpringBoard/SBAppSwitcherModel.h
@@ -6,7 +6,7 @@
 
 - (void)addToFront:(SBDisplayLayout *)layout NS_DEPRECATED_IOS(4_0, 9_0);
 - (NSArray *)snapshotOfFlattenedArrayOfAppIdentifiersWhichIsOnlyTemporary NS_DEPRECATED_IOS(8_0, 9_0);
-- (void)removeDisplayItem:(SBDisplayItem *)item NS_DEPRECATED_IOS(8_0, 9_0)
+- (void)removeDisplayItem:(SBDisplayItem *)item NS_DEPRECATED_IOS(8_0, 9_0);
 
 - (void)addToFront:(SBDisplayItem *)item role:(NSInteger)role NS_AVAILABLE_IOS(9_0);
 

--- a/SpringBoard/SBAppViewController.h
+++ b/SpringBoard/SBAppViewController.h
@@ -1,7 +1,7 @@
 #import <UIKit/UIViewController.h>
 #import "SBApplicationHosting.h"
 
-@class SBApplication, SBAppView, SBWorkspaceApplication. SBApplicationSceneEntity;
+@class SBApplication, SBAppView, SBWorkspaceApplication, SBApplicationSceneEntity;
 
 @interface SBAppViewController : UIViewController <SBApplicationHosting>
 @property (nonatomic, copy, readonly) NSString *bundleIdentifier;

--- a/SpringBoard/SBBBBulletinInfo.h
+++ b/SpringBoard/SBBBBulletinInfo.h
@@ -1,5 +1,7 @@
 #import "SBBBItemInfo.h"
 
+@class BBBulletin;
+
 @interface SBBBBulletinInfo : SBBBItemInfo
 
 @property (nonatomic, retain, readonly) BBBulletin *representedBulletin;

--- a/SpringBoard/SBBulletinBannerItem.h
+++ b/SpringBoard/SBBulletinBannerItem.h
@@ -1,3 +1,5 @@
+@class BBBulletin;
+
 @interface SBBulletinBannerItem : NSObject
 
 - (BBBulletin *)seedBulletin;

--- a/SpringBoard/SBFolderIconView.h
+++ b/SpringBoard/SBFolderIconView.h
@@ -1,4 +1,6 @@
-@class SBIconView, SBFolder;
+#import "SBIconView.h"
+
+@class SBFolder;
 
 @interface SBFolderIconView : SBIconView
 

--- a/SpringBoard/SBLockScreenNotificationListController.h
+++ b/SpringBoard/SBLockScreenNotificationListController.h
@@ -1,3 +1,5 @@
+@class BBObserver, BBBulletin;
+
 @interface SBLockScreenNotificationListController : UIViewController
 
 - (void)observer:(BBObserver *)observer addBulletin:(BBBulletin *)bulletin forFeed:(NSUInteger)feed;

--- a/SpringBoard/SBRootFolder.h
+++ b/SpringBoard/SBRootFolder.h
@@ -1,4 +1,6 @@
-@class SBFolder, SBIcon;
+#import "SBFolder.h"
+
+@class SBIcon;
 
 @interface SBRootFolder : SBFolder
 

--- a/Tweetbot/PTHAlertViewController.h
+++ b/Tweetbot/PTHAlertViewController.h
@@ -1,4 +1,4 @@
-@class PTHViewController;
+#import "PTHViewController.h"
 
 @interface PTHAlertViewController : PTHViewController
 

--- a/UIKit/UIActivityViewController+Private.h
+++ b/UIKit/UIActivityViewController+Private.h
@@ -1,3 +1,5 @@
+@class _UIActivityGroupListViewController;
+
 @interface UIActivityViewController (Private)
 
 @property (nonatomic, retain) _UIActivityGroupListViewController *activityGroupListViewController;

--- a/UIKit/UITableViewRowAction+Private.h
+++ b/UIKit/UITableViewRowAction+Private.h
@@ -1,5 +1,7 @@
 #import <UIKit/UIKit.h>
 
+@class _UITableViewCellActionButton;
+
 @interface UITableViewRowAction (Private)
 
 @property (retain, nonatomic) _UITableViewCellActionButton *_button;

--- a/UIKit/_UILayerHostView.h
+++ b/UIKit/_UILayerHostView.h
@@ -1,5 +1,7 @@
 #import <UIKit/UIView.h>
 
+@class CALayerHost;
+
 API_AVAILABLE(ios(9.0))
 @interface _UILayerHostView : UIView
 

--- a/UserNotificationsUIKit/NCNotificationRequest+Additions.h
+++ b/UserNotificationsUIKit/NCNotificationRequest+Additions.h
@@ -1,3 +1,5 @@
+@class BBBulletin;
+
 @interface NCNotificationRequest (Additions)
 
 @property (nonatomic, readonly) BBBulletin *bulletin;


### PR DESCRIPTION
These changes predominantly are `@class` declarations to improve importing headers independently. Per the [Code Rules](https://github.com/theos/headers#code-rules), headers should import e.g. Foundation and UIKit as needed. This commit does not include these types of imports as the diff would be substantially large, and I felt like some of these changes were important to get upstream quickly.

Additionally this fixes an issue brought up in https://github.com/theos/headers/commit/559da05801bb52765932af9531338d86f3a95abb#r43825152