### PR TITLE
Resolve std*11 warning in LightMessaging.h

### DIFF
--- a/LightMessaging/LightMessaging.h
+++ b/LightMessaging/LightMessaging.h
@@ -226,7 +226,7 @@ static inline void LMResponseBufferFree(LMResponseBuffer *responseBuffer)
 }
 
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-static inline kern_return_t LMStartServiceWithUserInfo(name_t serverName, CFRunLoopRef runLoop, CFMachPortCallBack callback, void *userInfo)
+static inline kern_return_t LMStartServiceWithUserInfo(const name_t serverName, CFRunLoopRef runLoop, CFMachPortCallBack callback, void *userInfo)
 {
 	// TODO: Figure out what the real interface is, implement service stopping, handle failures correctly
 	mach_port_t bootstrap = MACH_PORT_NULL;
@@ -243,12 +243,12 @@ static inline kern_return_t LMStartServiceWithUserInfo(name_t serverName, CFRunL
 }
 #pragma GCC diagnostic warning "-Wdeprecated-declarations"
 
-static inline kern_return_t LMStartService(name_t serverName, CFRunLoopRef runLoop, CFMachPortCallBack callback)
+static inline kern_return_t LMStartService(const name_t serverName, CFRunLoopRef runLoop, CFMachPortCallBack callback)
 {
 	return LMStartServiceWithUserInfo(serverName, runLoop, callback, NULL);
 }
 
-static inline kern_return_t LMCheckInService(name_t serverName, CFRunLoopRef runLoop, CFMachPortCallBack callback, void *userInfo)
+static inline kern_return_t LMCheckInService(const name_t serverName, CFRunLoopRef runLoop, CFMachPortCallBack callback, void *userInfo)
 {
 	// TODO: Figure out what the real interface is, implement service stopping, handle failures correctly
 	mach_port_t bootstrap = MACH_PORT_NULL;

--- a/bootstrap.h
+++ b/bootstrap.h
@@ -269,7 +269,7 @@ kern_return_t bootstrap_parent(
  */
 AVAILABLE_MAC_OS_X_VERSION_10_0_AND_LATER_BUT_DEPRECATED_IN_MAC_OS_X_VERSION_10_5
 kern_return_t
-bootstrap_register(mach_port_t bp, name_t service_name, mach_port_t sp);
+bootstrap_register(mach_port_t bp, const name_t service_name, mach_port_t sp);
 
 /*
  * bootstrap_create_service()

--- a/rocketbootstrap/rocketbootstrap.h
+++ b/rocketbootstrap/rocketbootstrap.h
@@ -9,7 +9,7 @@ kern_return_t rocketbootstrap_look_up(mach_port_t bp, const name_t service_name,
 
 
 kern_return_t rocketbootstrap_unlock(const name_t service_name); // Errors if not in a privileged process such as SpringBoard or backboardd
-kern_return_t rocketbootstrap_register(mach_port_t bp, name_t service_name, mach_port_t sp); // Errors if not in a privileged process such as SpringBoard or backboardd
+kern_return_t rocketbootstrap_register(mach_port_t bp, const name_t service_name, mach_port_t sp); // Errors if not in a privileged process such as SpringBoard or backboardd
 
 #ifdef __COREFOUNDATION_CFMESSAGEPORT__
 CFMessagePortRef rocketbootstrap_cfmessageportcreateremote(CFAllocatorRef allocator, CFStringRef name);


### PR DESCRIPTION
`serverName` should be `const name_t` not just `name_t` or you get a warning for pointer decay from a string literal into `char *`