### PR TITLE
Availability (`API_{AVAILABLE,DEPRECATED}`) updates

### DIFF
--- a/AddressBookUI/ABMonogrammer.h
+++ b/AddressBookUI/ABMonogrammer.h
@@ -1,3 +1,5 @@
+#import <Foundation/Foundation.h>
+
 typedef NS_ENUM(NSUInteger, ABMonogrammerStyle) {
 	ABMonogrammerStyleLightGray,
 	ABMonogrammerStyleWhite,
@@ -5,6 +7,11 @@ typedef NS_ENUM(NSUInteger, ABMonogrammerStyle) {
 	ABMonogrammerStyleLightGraySemitransparent,
 };
 
+/* Removed in iOS 11
+ * superclass changed to CNMonogrammer in iOS 9,
+ *   and almost all functionality was moved there as well
+ */
+API_DEPRECATED_WITH_REPLACEMENT("CNMonogrammer", ios(7.0, 11.0))
 @interface ABMonogrammer : NSObject
 
 - (instancetype)initWithStyle:(ABMonogrammerStyle)style diameter:(CGFloat)diameter;

--- a/BiometricKit/BiometricKit.h
+++ b/BiometricKit/BiometricKit.h
@@ -23,7 +23,7 @@ API_AVAILABLE(ios(7.0))
 - (NSUUID *)getIdentitiesDatabaseUUIDForUser:(uid_t)user API_AVAILABLE(ios(10.0));
 - (NSData *)getIdentitiesDatabaseHashForUser:(uid_t)user API_AVAILABLE(ios(10.0));
 
-- (NSUUID *)getIdentitiesDatabaseUUID API_DEPRECATED("getIdentitiesDatabaseUUIDForUser:", ios(9.0, 10.0));
-- (NSData *)getIdentitiesDatabaseHash API_DEPRECATED("getIdentitiesDatabaseHashForUser:", ios(9.0, 10.0));
+- (NSUUID *)getIdentitiesDatabaseUUID API_DEPRECATED_WITH_REPLACEMENT("getIdentitiesDatabaseUUIDForUser:", ios(9.0, 10.0));
+- (NSData *)getIdentitiesDatabaseHash API_DEPRECATED_WITH_REPLACEMENT("getIdentitiesDatabaseHashForUser:", ios(9.0, 10.0));
 
 @end

--- a/MobileCoreServices/LSAppLink.h
+++ b/MobileCoreServices/LSAppLink.h
@@ -1,3 +1,5 @@
+#import <Foundation/Foundation.h>
+
 @class LSApplicationProxy;
 
 typedef NS_ENUM(NSInteger, LSAppLinkOpenStrategy) {
@@ -7,10 +9,11 @@ typedef NS_ENUM(NSInteger, LSAppLinkOpenStrategy) {
 	LSAppLinkOpenStrategyBrowser,
 };
 
+API_AVAILABLE(ios(9.0))
 @interface LSAppLink : NSObject
 
-+ (instancetype)_appLinkWithURL:(NSURL *)url applicationProxy:(LSApplicationProxy *)applicationProxy plugIn:(id)plugIn error:(NSError **)error NS_DEPRECATED_IOS(9_0, 11_0);
-+ (instancetype)_appLinkWithURL:(NSURL *)url applicationProxy:(LSApplicationProxy *)applicationProxy plugIn:(id)plugIn NS_AVAILABLE_IOS(11_0);
++ (instancetype)_appLinkWithURL:(NSURL *)url applicationProxy:(LSApplicationProxy *)applicationProxy plugIn:(id)plugIn error:(NSError **)error API_DEPRECATED_WITH_REPLACEMENT("_appLinkWithURL:applicationProxy:plugIn:", ios(9.0, 11.0));
++ (instancetype)_appLinkWithURL:(NSURL *)url applicationProxy:(LSApplicationProxy *)applicationProxy plugIn:(id)plugIn API_AVAILABLE(ios(11.0));
 
 @property (nonatomic, retain) NSURL *URL;
 @property (nonatomic, retain) LSApplicationProxy *targetApplicationProxy;

--- a/MobileCoreServices/LSApplicationProxy.h
+++ b/MobileCoreServices/LSApplicationProxy.h
@@ -2,32 +2,35 @@
 
 @class LSPlugInKitProxy;
 
+API_AVAILABLE(ios(4.0))
 @interface LSApplicationProxy : LSBundleProxy
 
 + (instancetype)applicationProxyForIdentifier:(NSString *)identifier;
 
 @property (nonatomic, readonly) NSString *applicationIdentifier;
-@property (nonatomic, readonly) NSString *sourceAppIdentifier; // e.g. App Store, TestFlight
-@property (nonatomic, readonly) NSString *itemName;
-@property (nonatomic, readonly) NSString *sdkVersion;
-@property (nonatomic, readonly) NSString *teamID;
-@property (nonatomic, readonly) NSString *vendorName;
-@property (nonatomic, readonly) NSDate *registeredDate;
+@property (nonatomic, readonly) NSString *vendorName   API_AVAILABLE(ios(7.0));
+@property (nonatomic, readonly) NSString *itemName     API_AVAILABLE(ios(7.1));
+@property (nonatomic, readonly) NSString *sdkVersion   API_AVAILABLE(ios(8.0));
+@property (nonatomic, readonly) NSString *teamID       API_AVAILABLE(ios(8.0));
+@property (nonatomic, readonly) NSDate *registeredDate API_AVAILABLE(ios(9.0));
+@property (nonatomic, readonly) NSString *sourceAppIdentifier API_AVAILABLE(ios(8.2)); // e.g. App Store, TestFlight
 
-@property (nonatomic, readonly) NSArray <LSPlugInKitProxy *> *plugInKitPlugins;
-@property (nonatomic, readonly) NSArray <NSNumber *> *deviceFamily;
-@property (nonatomic, readonly) NSArray <NSString *> *activityTypes;
+@property (nonatomic, readonly) NSArray <LSPlugInKitProxy *> *plugInKitPlugins API_AVAILABLE(ios(8.0));
+@property (nonatomic, readonly) NSArray <NSNumber *> *deviceFamily  API_AVAILABLE(ios(8.0));
+@property (nonatomic, readonly) NSArray <NSString *> *activityTypes API_AVAILABLE(ios(10.0));
 
-@property (nonatomic, readonly) BOOL isAdHocCodeSigned;
-@property (nonatomic, readonly) BOOL isAppUpdate;
-@property (nonatomic, readonly) BOOL isBetaApp;
-@property (nonatomic, readonly) BOOL isInstalled;
-@property (nonatomic, readonly) BOOL isLaunchProhibited;
-@property (nonatomic, readonly) BOOL isNewsstandApp;
-@property (nonatomic, readonly) BOOL isPlaceholder;
-@property (nonatomic, readonly) BOOL isPurchasedReDownload;
-@property (nonatomic, readonly) BOOL isRestricted;
-@property (nonatomic, readonly) BOOL isStickerProvider;
-@property (nonatomic, readonly) BOOL isWatchKitApp;
+@property (nonatomic, readonly, getter=isAppUpdate) BOOL appUpdate API_AVAILABLE(ios(7.0));
+@property (nonatomic, readonly, getter=isInstalled) BOOL installed API_AVAILABLE(ios(7.0));
+@property (nonatomic, readonly, getter=isNewsstandApp) BOOL newsstandApp API_AVAILABLE(ios(7.0));
+@property (nonatomic, readonly, getter=isPlaceholder) BOOL placeholder   API_AVAILABLE(ios(7.0));
+@property (nonatomic, readonly, getter=isRestricted) BOOL restricted     API_AVAILABLE(ios(7.0));
+@property (nonatomic, readonly, getter=isPurchasedReDownload) BOOL purchasedReDownload API_AVAILABLE(ios(8.0));
+@property (nonatomic, readonly, getter=isWatchKitApp) BOOL watchKitApp API_AVAILABLE(ios(8.2));
+@property (nonatomic, readonly, getter=isBetaApp) BOOL betaApp         API_AVAILABLE(ios(8.2));
+@property (nonatomic, readonly, getter=isAdHocCodeSigned) BOOL adHocCodeSigned   API_AVAILABLE(ios(9.0));
+@property (nonatomic, readonly, getter=isLaunchProhibited) BOOL launchProhibited API_AVAILABLE(ios(10.0));
+@property (nonatomic, readonly, getter=isAppStoreVendable) BOOL appStoreVendable API_AVAILABLE(ios(11.0));
+
+@property (nonatomic, readonly) BOOL isStickerProvider API_DEPRECATED("Removed in iOS 11", ios(10.0, 11.0));
 
 @end

--- a/MobileCoreServices/LSBundleProxy.h
+++ b/MobileCoreServices/LSBundleProxy.h
@@ -1,8 +1,9 @@
 #import "LSResourceProxy.h"
 
+API_AVAILABLE(ios(8.0))
 @interface LSBundleProxy : LSResourceProxy
 
-+ (instancetype)bundleProxyForCurrentProcess;
++ (instancetype)bundleProxyForCurrentProcess API_AVAILABLE(ios(10.0));
 + (instancetype)bundleProxyForIdentifier:(NSString *)identifier;
 + (instancetype)bundleProxyForURL:(NSURL *)url;
 
@@ -17,6 +18,7 @@
 @property (nonatomic, readonly) NSString *bundleExecutable;
 @property (nonatomic, readonly) NSString *bundleIdentifier;
 @property (nonatomic, readonly) NSString *bundleType;
+@property (nonatomic, readonly) NSString *canonicalExecutablePath API_AVAILABLE(ios(10.3));
 
 @property (nonatomic, readonly) NSDictionary <NSString *, NSString *> *entitlements;
 @property (nonatomic, readonly) NSDictionary <NSString *, NSString *> *environmentVariables;
@@ -24,11 +26,11 @@
 
 @property (nonatomic, copy) NSArray <NSUUID *> *machOUUIDs;
 @property (nonatomic, readonly) NSString *signerIdentity;
-@property (nonatomic, readonly) BOOL isContainerized;
-@property (nonatomic, readonly) BOOL profileValidated;
+@property (nonatomic, readonly, getter=isContainerized) BOOL containerized API_AVAILABLE(ios(11.0));
+@property (nonatomic, readonly) BOOL profileValidated API_AVAILABLE(ios(11.0));
 
 @property (nonatomic, readonly) NSString *localizedShortName;
 
-- (NSUUID *)uniqueIdentifier;
+- (NSUUID *)uniqueIdentifier API_AVAILABLE(ios(9.0));
 
 @end

--- a/MobileCoreServices/LSResourceProxy.h
+++ b/MobileCoreServices/LSResourceProxy.h
@@ -1,10 +1,11 @@
 #import "_LSQueryResult.h"
 
+API_AVAILABLE(ios(4.0)) // subclass of NSObject until iOS 10.0
 @interface LSResourceProxy : _LSQueryResult
 
 @property (nonatomic, copy) NSString *boundApplicationIdentifier;
-@property (nonatomic, copy) NSURL *boundContainerURL;
-@property (nonatomic, copy) NSURL *boundDataContainerURL;
+@property (nonatomic, copy) NSURL *boundContainerURL API_AVAILABLE(ios(5.0));
+@property (nonatomic, copy) NSURL *boundDataContainerURL API_DEPRECATED("Access through the appropriate subclass property", ios(8.0, 11.0));
 
 @property (nonatomic, retain) NSString *localizedName;
 

--- a/MobileCoreServices/_LSQueryResult.h
+++ b/MobileCoreServices/_LSQueryResult.h
@@ -1,3 +1,6 @@
-@interface _LSQueryResult : NSObject
+#import <Foundation/Foundation.h>
+
+API_AVAILABLE(ios(10.0))
+@interface _LSQueryResult : NSObject <NSCopying, NSSecureCoding>
 
 @end

--- a/SpringBoard/VolumeControl.h
+++ b/SpringBoard/VolumeControl.h
@@ -1,4 +1,4 @@
-API_DEPRECATED("Use SBVolumeControl", ios(2.0, 13.0))
+API_DEPRECATED_WITH_REPLACEMENT("SBVolumeControl", ios(2.0, 13.0))
 @interface VolumeControl : NSObject
 
 + (instancetype)sharedVolumeControl;


### PR DESCRIPTION
Deprecate `ABMonogrammer` (with replacement)

Adds availability attributes to `MobileCoreServices` classes

Update a few occurrences of `API_DEPRECATED` with `API_DEPRECATED_WITH_REPLACEMENT`