### PR TITLE
fix spelling error in MobileGestalt.h + added MIDaemonConfiguration API to installd

### DIFF
--- a/MobileGestalt/MobileGestalt.h
+++ b/MobileGestalt/MobileGestalt.h
@@ -27,7 +27,7 @@ typedef enum {
 #pragma mark - API
 
 FOUNDATION_EXPORT CFTypeRef MGCopyAnswer(CFStringRef question, CFDictionaryRef options);
-FOUNDATION_EXPORT CFTypeRef CFTypeRef MGCopyAnswerWithError(CFStringRef question, CFDictionaryRef options, int *error);
+FOUNDATION_EXPORT CFTypeRef MGCopyAnswerWithError(CFStringRef question, CFDictionaryRef options, int *error);
 
 FOUNDATION_EXPORT bool MGGetBoolAnswer(CFStringRef question);
 FOUNDATION_EXPORT bool MGIsQuestionValid(CFStringRef question);

--- a/installd/MIDaemonConfiguration.h
+++ b/installd/MIDaemonConfiguration.h
@@ -7,8 +7,4 @@ API_AVAILABLE(ios(13.0))
 @property (nonatomic, readonly) BOOL skipThinningCheck; 
 @property (nonatomic, readonly) BOOL allowPatchWithoutSinf; 
 
-- (BOOL)skipDeviceFamilyCheck;
-- (BOOL)skipThinningCheck;
-- (BOOL)allowPatchWithoutSinf;
-
 @end

--- a/installd/MIDaemonConfiguration.h
+++ b/installd/MIDaemonConfiguration.h
@@ -1,0 +1,13 @@
+#import "MIGlobalConfiguration.h"
+
+@interface MIDaemonConfiguration : MIGlobalConfiguration
+
+@property (nonatomic,readonly) BOOL skipDeviceFamilyCheck; 
+@property (nonatomic,readonly) BOOL skipThinningCheck; 
+@property (nonatomic,readonly) BOOL allowPatchWithoutSinf; 
+
+- (BOOL)skipDeviceFamilyCheck;
+- (BOOL)skipThinningCheck;
+- (BOOL)allowPatchWithoutSinf;
+
+@end

--- a/installd/MIDaemonConfiguration.h
+++ b/installd/MIDaemonConfiguration.h
@@ -1,5 +1,6 @@
 #import "MIGlobalConfiguration.h"
 
+API_AVAILABLE(ios(13.0))
 @interface MIDaemonConfiguration : MIGlobalConfiguration
 
 @property (nonatomic,readonly) BOOL skipDeviceFamilyCheck; 

--- a/installd/MIDaemonConfiguration.h
+++ b/installd/MIDaemonConfiguration.h
@@ -3,9 +3,9 @@
 API_AVAILABLE(ios(13.0))
 @interface MIDaemonConfiguration : MIGlobalConfiguration
 
-@property (nonatomic,readonly) BOOL skipDeviceFamilyCheck; 
-@property (nonatomic,readonly) BOOL skipThinningCheck; 
-@property (nonatomic,readonly) BOOL allowPatchWithoutSinf; 
+@property (nonatomic, readonly) BOOL skipDeviceFamilyCheck; 
+@property (nonatomic, readonly) BOOL skipThinningCheck; 
+@property (nonatomic, readonly) BOOL allowPatchWithoutSinf; 
 
 - (BOOL)skipDeviceFamilyCheck;
 - (BOOL)skipThinningCheck;

--- a/installd/MIGlobalConfiguration.h
+++ b/installd/MIGlobalConfiguration.h
@@ -1,0 +1,3 @@
+@interface MIGlobalConfiguration : NSObject
+
+@end


### PR DESCRIPTION
There are a couple more properties in MIDaemonConfiguration that I purposely left out because they do not work, the ones left intact do work, but only when dealing with installd directly (Example; https://repo.packix.com/package/daniel.midaemontweak/)