### PR TITLE
Fix xpc_object_t 'expected a type' error in Foundation/NSXPCConnection.h

### DIFF
--- a/Foundation/NSXPCConnection.h
+++ b/Foundation/NSXPCConnection.h
@@ -2,6 +2,10 @@
 #import <Foundation/NSString.h>
 #import <Foundation/NSCoder.h>
 
+#if __has_include(<xpc/xpc.h>)
+    #import <xpc/xpc.h>
+#endif
+
 @class NSXPCConnection, NSXPCListener, NSXPCInterface, NSXPCListenerEndpoint;
 @protocol NSXPCListenerDelegate;
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link below to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
When attempting to compile a fresh project created from the xpc_service nic template, Foundation fails to build due to an unknown type error and the compilation fails. This resolves that unknown type error by importing the relevant header if necessary. 

Does this close any currently open issues?
------------------------------------------
I don't think so, no. 

Any relevant logs, error output, etc?
-------------------------------------
```
==> Compiling main.m (arm64)…
While building module 'Foundation' imported from main.m:1:
In file included from <module-includes>:1:
In file included from /home/lightmann/theos/sdks/iPhoneOS14.5.sdk/System/Library/Frameworks/Foundation.framework/Headers/Foundation.h:98:
/home/lightmann/theos/vendor/include/Foundation/NSXPCConnection.h:93:21: error: expected a type
- (void)setXPCType:(xpc_type_t)type forSelector:(SEL)selector argumentIndex:(NSUInteger)index ofReply:(BOOL)ofReply API_AVAILABLE(ios(13.0));
                    ^
/home/lightmann/theos/vendor/include/Foundation/NSXPCConnection.h:94:13: error: expected a type
- (nullable xpc_type_t)XPCTypeForSelector:(SEL)selector argumentIndex:(NSUInteger)index ofReply:(BOOL)ofReply API_AVAILABLE(ios(13.0));
            ^
/home/lightmann/theos/vendor/include/Foundation/NSXPCConnection.h:110:13: error: expected a type
- (nullable xpc_object_t)decodeXPCObjectOfType:(xpc_type_t)type forKey:(NSString *)key API_AVAILABLE(ios(7.0));
            ^
/home/lightmann/theos/vendor/include/Foundation/NSXPCConnection.h:110:49: error: expected a type
- (nullable xpc_object_t)decodeXPCObjectOfType:(xpc_type_t)type forKey:(NSString *)key API_AVAILABLE(ios(7.0));
                                                ^
/home/lightmann/theos/vendor/include/Foundation/NSXPCConnection.h:111:26: error: expected a type
- (void)encodeXPCObject:(xpc_object_t)xpcObject forKey:(NSString *)key;
                         ^
main.m:1:9: fatal error: could not build module 'Foundation'
#import <Foundation/NSRunLoop.h>
 ~~~~~~~^
6 errors generated.
```

Any other comments?
-------------------
Nope

Where has this been tested?
---------------------------
**Operating System:** …

Linux (WSL)

**Platform:** …

**Target Platform:** …

**Toolchain Version:** …

**SDK Version:** …
