### PR TITLE
[version] Added CoreFoundation versions for iOS 14.6 - 15.3

### DIFF
--- a/version.h
+++ b/version.h
@@ -255,6 +255,22 @@
 #define kCFCoreFoundationVersionNumber_iOS_14_5 1775.118
 #endif
 
+#ifndef kCFCoreFoundationVersionNumber_iOS_15_0
+#define kCFCoreFoundationVersionNumber_iOS_15_0 1854
+#endif
+
+#ifndef kCFCoreFoundationVersionNumber_iOS_15_1
+#define kCFCoreFoundationVersionNumber_iOS_15_1 1855.105
+#endif
+
+#ifndef kCFCoreFoundationVersionNumber_iOS_15_2
+#define kCFCoreFoundationVersionNumber_iOS_15_2 1856.105
+#endif
+
+#ifndef kCFCoreFoundationVersionNumber_iOS_15_3
+#define kCFCoreFoundationVersionNumber_iOS_15_3 1856.105
+#endif
+
 #ifndef kCFCoreFoundationVersionNumber10_10
 #define kCFCoreFoundationVersionNumber10_10 1151.16
 #endif

--- a/version.h
+++ b/version.h
@@ -56,6 +56,13 @@
  * 14.3     1770.300
  * 14.4     1774.101
  * 14.5     1775.118
+ * 14.6     1776.103
+ * 14.7     1777.103
+ * 14.8     1778.101
+ * 15.0     1854
+ * 15.1     1855.105
+ * 15.2     1856.105
+ * 15.3     1856.105
  *
  * Reference:
  * http://iphonedevwiki.net/index.php/CoreFoundation.framework#Versions
@@ -253,6 +260,18 @@
 
 #ifndef kCFCoreFoundationVersionNumber_iOS_14_5
 #define kCFCoreFoundationVersionNumber_iOS_14_5 1775.118
+#endif
+
+#ifndef kCFCoreFoundationVersionNumber_iOS_14_6
+#define kCFCoreFoundationVersionNumber_iOS_14_6 1776.103
+#endif
+
+#ifndef kCFCoreFoundationVersionNumber_iOS_14_7
+#define kCFCoreFoundationVersionNumber_iOS_14_7 1777.103
+#endif
+
+#ifndef kCFCoreFoundationVersionNumber_iOS_14_8
+#define kCFCoreFoundationVersionNumber_iOS_14_8 1778.101
 #endif
 
 #ifndef kCFCoreFoundationVersionNumber_iOS_15_0


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link below to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
…

Checklist
---------
- [ ] New code follows the [code rules](https://github.com/theos/headers/blob/master/README.md#code-rules)
- [ ] I've added modulemaps for any new libraries (e.g. see [libactivator/module.modulemap](https://github.com/theos/headers/blob/f3e596d896bae8f07c43cfb00ef55bf6224b4cdc/libactivator/module.modulemap)): it should be possible to `@import MyLibrary;` in ObjC, or `import MyLibrary` in Swift.
- [ ] My contribution is code written by myself from reverse-engineered headers, licensed into the Public Domain as per [LICENSE.md](LICENSE.md); or, code written by myself / taken from an existing project, released under an OSI-approved license, and I've added relevant licensing credit to [LICENSE.md](LICENSE.md)


Does this close any currently open issues?
------------------------------------------
…

Any relevant logs, error output, etc?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
**Operating System:** …

**Platform:** …

**Target Platform:** …

**Toolchain Version:** …

**SDK Version:** …
