### PR TITLE
[MobileGestalt] Added more device classes

### DIFF
--- a/MobileGestalt/MobileGestalt.h
+++ b/MobileGestalt/MobileGestalt.h
@@ -20,7 +20,7 @@ typedef enum {
     MGDeviceClassiPod           = 2,
     MGDeviceClassiPad           = 3,
     MGDeviceClassAppleTV        = 4,
-    /* 5 is intentionally not in this enum */
+    MGDeviceClassiFPGA           = 5,
     MGDeviceClassWatch          = 6,
     MGDeviceClassAudioAccessory = 7,
     MGDeviceClassiBridge        = 8,

--- a/MobileGestalt/MobileGestalt.h
+++ b/MobileGestalt/MobileGestalt.h
@@ -14,14 +14,18 @@
 #include <sys/cdefs.h>
 
 typedef enum {
-    MGDeviceClassInvalid = -1,
+    MGDeviceClassInvalid        = -1,
     /* 0 is intentionally not in this enum */
-    MGDeviceClassiPhone  = 1,
-    MGDeviceClassiPod    = 2,
-    MGDeviceClassiPad    = 3,
-    MGDeviceClassAppleTV = 4,
+    MGDeviceClassiPhone         = 1,
+    MGDeviceClassiPod           = 2,
+    MGDeviceClassiPad           = 3,
+    MGDeviceClassAppleTV        = 4,
     /* 5 is intentionally not in this enum */
-    MGDeviceClassWatch   = 6,
+    MGDeviceClassWatch          = 6,
+    MGDeviceClassAudioAccessory = 7,
+    MGDeviceClassiBridge        = 8,
+    MGDeviceClassMac            = 9,
+    MGDeviceClassAppleDisplay   = 10,
 } MGDeviceClass;
 
 #pragma mark - API


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link below to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
…

Checklist
---------
- [x] New code follows the [code rules](https://github.com/theos/headers/blob/master/README.md#code-rules)
- [ ] I've added modulemaps for any new libraries (e.g. see [libactivator/module.modulemap](https://github.com/theos/headers/blob/f3e596d896bae8f07c43cfb00ef55bf6224b4cdc/libactivator/module.modulemap)): it should be possible to `@import MyLibrary;` in ObjC, or `import MyLibrary` in Swift.
- [x] My contribution is code written by myself from reverse-engineered headers, licensed into the Public Domain as per [LICENSE.md](LICENSE.md); or, code written by myself / taken from an existing project, released under an OSI-approved license, and I've added relevant licensing credit to [LICENSE.md](LICENSE.md)


Does this close any currently open issues?
------------------------------------------
…

Any relevant logs, error output, etc?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
**Operating System:** …

**Platform:** …

**Target Platform:** …

**Toolchain Version:** …

**SDK Version:** …
