### PR TITLE
[OnBoardingKit] Added OBPrivacyLinkButton

### DIFF
--- a/OnBoardingKit/OBPrivacyLinkButton.h
+++ b/OnBoardingKit/OBPrivacyLinkButton.h
@@ -1,0 +1,9 @@
+#import <UIKit/UIKit.h>
+
+API_AVAILABLE(ios(13.0))
+@interface OBPrivacyLinkButton : UIButton
+
+- (instancetype)initWithCaption:(NSString *)caption buttonText:(NSString *)buttonText image:(UIImage *)image imageSize:(CGSize)imageSize useLargeIcon:(BOOL)useLargeIcon API_DEPRECATED("Use the method with displayLanguage parameter instead", ios(13.0, 15.6));
+- (instancetype)initWithCaption:(NSString *)caption buttonText:(NSString *)buttonText image:(UIImage *)image imageSize:(CGSize)imageSize useLargeIcon:(BOOL)useLargeIcon displayLanguage:(NSString *)displayLanguage API_AVAILABLE(ios(16.0));
+
+@end

--- a/OnBoardingKit/OBPrivacyLinkButton.h
+++ b/OnBoardingKit/OBPrivacyLinkButton.h
@@ -3,7 +3,7 @@
 API_AVAILABLE(ios(13.0))
 @interface OBPrivacyLinkButton : UIButton
 
-- (instancetype)initWithCaption:(NSString *)caption buttonText:(NSString *)buttonText image:(UIImage *)image imageSize:(CGSize)imageSize useLargeIcon:(BOOL)useLargeIcon API_DEPRECATED("Use the method with displayLanguage parameter instead", ios(13.0, 15.6));
+- (instancetype)initWithCaption:(NSString *)caption buttonText:(NSString *)buttonText image:(UIImage *)image imageSize:(CGSize)imageSize useLargeIcon:(BOOL)useLargeIcon API_DEPRECATED("Use the method with displayLanguage parameter instead", ios(13.0, 15.7));
 - (instancetype)initWithCaption:(NSString *)caption buttonText:(NSString *)buttonText image:(UIImage *)image imageSize:(CGSize)imageSize useLargeIcon:(BOOL)useLargeIcon displayLanguage:(NSString *)displayLanguage API_AVAILABLE(ios(16.0));
 
 @end


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link below to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
…

Checklist
---------
- [x] New code follows the [code rules](https://github.com/theos/headers/blob/master/README.md#code-rules)
- [ ] I've added modulemaps for any new libraries (e.g. see [libactivator/module.modulemap](https://github.com/theos/headers/blob/f3e596d896bae8f07c43cfb00ef55bf6224b4cdc/libactivator/module.modulemap)): it should be possible to `@import MyLibrary;` in ObjC, or `import MyLibrary` in Swift.
- [x] My contribution is code written by myself from reverse-engineered headers, licensed into the Public Domain as per [LICENSE.md](LICENSE.md); or, code written by myself / taken from an existing project, released under an OSI-approved license, and I've added relevant licensing credit to [LICENSE.md](LICENSE.md)


Does this close any currently open issues?
------------------------------------------
…

Any relevant logs, error output, etc?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
**Operating System:** …

**Platform:** …

**Target Platform:** …

**Toolchain Version:** …

**SDK Version:** …
