### PR TITLE
[meta] Removed trailing spaces from the headers

### DIFF
--- a/ControlCenterUIKit/CCUILabeledRoundButtonViewController.h
+++ b/ControlCenterUIKit/CCUILabeledRoundButtonViewController.h
@@ -23,7 +23,7 @@ API_AVAILABLE(ios(11.0))
 @property (nonatomic, retain) CCUICAPackageDescription *glyphPackageDescription;
 
 @property (nonatomic, copy) NSString *glyphState;
-@property (nonatomic, copy) NSString *title; 
+@property (nonatomic, copy) NSString *title;
 @property (nonatomic, copy) NSString *subtitle;
 
 - (instancetype)initWithGlyphImage:(UIImage *)glyphImage highlightColor:(UIColor *)highlightColor;

--- a/FrontBoardServices/FBSMutableSceneSettings.h
+++ b/FrontBoardServices/FBSMutableSceneSettings.h
@@ -2,6 +2,6 @@
 
 @interface FBSMutableSceneSettings : FBSSceneSettings
 
-@property (nonatomic, assign, getter=isBackgrounded) BOOL backgrounded; 
+@property (nonatomic, assign, getter=isBackgrounded) BOOL backgrounded;
 
 @end

--- a/IOKit/IOMessage.h
+++ b/IOKit/IOMessage.h
@@ -138,7 +138,7 @@ typedef UInt32 IOMessage;
 
 /*!
  * @defined         kIOMessageSystemWillNotSleep
- * @discussion      Announces that the system has retracted a previous attempt to sleep; 
+ * @discussion      Announces that the system has retracted a previous attempt to sleep;
  *                  it follows <code>kIOMessageCanSystemSleep</code>.
  *                  Delivered to in-kernel IOKit drivers via <code>kIOGeneralInterest</code>
  *                  and <code>kIOPriorityPowerStateInterest</code>.
@@ -187,7 +187,7 @@ typedef UInt32 IOMessage;
 
 /*! 
  * @defined         kIOMessageDeviceWillNotPowerOff
- * @discussion      This IOKit interest notification is largely unused; 
+ * @discussion      This IOKit interest notification is largely unused;
  *                  it's not very interesting.
  */
 #define kIOMessageDeviceWillNotPowerOff    iokit_common_msg(0x220)

--- a/IOKit/hid/IOHIDEventData.h
+++ b/IOKit/hid/IOHIDEventData.h
@@ -126,12 +126,12 @@ typedef struct _IOHIDAmbientLightSensorEventData {
 } IOHIDAmbientLightSensorEventData;
 
 typedef struct _IOHIDTemperatureEventData {
-    IOHIDEVENT_BASE;                            
+    IOHIDEVENT_BASE;
     IOFixed        level;
 } IOHIDTemperatureEventData;
 
 typedef struct _IOHIDProximityEventData {
-    IOHIDEVENT_BASE;                            
+    IOHIDEVENT_BASE;
     uint32_t        detectionMask;
 } IOHIDProximityEventData;
 
@@ -166,7 +166,7 @@ typedef struct _IOHIDDigitizerEventData {
     IOHIDEVENT_BASE;                            // options = kIOHIDTransducerRange, kHIDTransducerTouch, kHIDTransducerInvert
     IOHIDAXISEVENT_BASE;						// 3c, 40, 44
 
-    uint32_t        transducerIndex;   
+    uint32_t        transducerIndex;
     uint32_t        transducerType;				// could overload this to include that both the hand and finger id.
     uint32_t        identity;                   // Specifies a unique ID of the current transducer action.
     uint32_t        eventMask;                  // the type of event that has occurred: range, touch, position
@@ -199,7 +199,7 @@ typedef struct _IOHIDDigitizerEventData {
 } IOHIDDigitizerEventData;
 
 typedef struct _IOHIDSwipeEventData {
-    IOHIDEVENT_BASE;                            
+    IOHIDEVENT_BASE;
     IOHIDSwipeMask swipeMask;
 } IOHIDSwipeEventData;
 
@@ -226,7 +226,7 @@ typedef struct _IOHIDSystemQueueElement {
     uint32_t        options;
     uint32_t        eventCount;
     IOHIDEventData  events[];
-} IOHIDSystemQueueElement; 
+} IOHIDSystemQueueElement;
 
 //******************************************************************************
 // MACROS

--- a/IOKit/hid/IOHIDEventTypes.h
+++ b/IOKit/hid/IOHIDEventTypes.h
@@ -362,7 +362,7 @@ typedef struct _IOHID3DPoint {
     IOHIDFloat  x;
     IOHIDFloat  y;
     IOHIDFloat  z;
-} IOHID3DPoint; 
+} IOHID3DPoint;
 #endif
 
 #endif /* _IOKIT_HID_IOHIDEVENTTYPES_H */

--- a/IOKit/ps/IOPSKeys.h
+++ b/IOKit/ps/IOPSKeys.h
@@ -233,7 +233,7 @@
  *              <ul>
  *              <li> Apple-defined power sources will publish this key.
  *              <li> For power source creators: Providing this key is REQUIRED.
- *              <li> <code>@link kIOPSBatteryPowerValue @/link</code> indicates power source is drawing internal power; 
+ *              <li> <code>@link kIOPSBatteryPowerValue @/link</code> indicates power source is drawing internal power;
  *                   <code>@link kIOPSACPowerValue@/link</code> indicates power source is connected to an external power source.
  *              <li> Type CFString, value is <code>@link kIOPSACPowerValue@/link</code>, <code>@link kIOPSBatteryPowerValue@/link</code>, or <code>@link kIOPSOffLineValue@/link</code>.
  *              </ul>

--- a/IOKit/pwr_mgt/IOPMLib.h
+++ b/IOKit/pwr_mgt/IOPMLib.h
@@ -173,7 +173,7 @@ io_connect_t IORegisterForSystemPower ( void * refcon,
                                         IONotificationPortRef * thePortRef,
                                         IOServiceInterestCallback callback,
                                         io_object_t * notifier )
-                                        AVAILABLE_MAC_OS_X_VERSION_10_0_AND_LATER;                                        
+                                        AVAILABLE_MAC_OS_X_VERSION_10_0_AND_LATER;
 /*! @function           IODeregisterApp
     @abstract           Disconnects the caller from an IOService after receiving power state change notifications from the IOService. (Caller must also release IORegisterApp's return io_connect_t and returned IONotificationPortRef for complete clean-up).
     @param notifier     An object from IORegisterApp.
@@ -251,7 +251,7 @@ IOReturn IOPMCancelScheduledPowerEvent(CFDateRef time_to_wake, CFStringRef my_id
     @discussion Returns a CFArray of CFDictionaries of power events. Each CFDictionary  contains keys for CFSTR(kIOPMPowerEventTimeKey), CFSTR(kIOPMPowerEventAppNameKey), and CFSTR(kIOPMPowerEventTypeKey).
     @result A CFArray of CFDictionaries of power events. The CFArray must be released by the caller. NULL if there are no scheduled events.
 */
-CFArrayRef IOPMCopyScheduledPowerEvents(void); 
+CFArrayRef IOPMCopyScheduledPowerEvents(void);
 
 
 
@@ -873,7 +873,7 @@ IOReturn IOPMAssertionCreateWithName(
                         IOPMAssertionLevel   AssertionLevel,
                         CFStringRef          AssertionName,
                         IOPMAssertionID      *AssertionID)
-                        AVAILABLE_MAC_OS_X_VERSION_10_6_AND_LATER;                           
+                        AVAILABLE_MAC_OS_X_VERSION_10_6_AND_LATER;
                            
 
 /*!
@@ -989,7 +989,7 @@ CFDictionaryRef IOCopySystemLoadAdvisoryDetailed(void);
  *                  - kIOPMCPUPowerLimitProcessorSpeedKey
  *                  - kIOPMCPUPowerLimitProcessorCountKey
  *                  - kIOPMCPUPowerLimitSchedulerTimeKey        
- * @param       cpuPowerStatus Upon success, a pointer to a dictionary defining CPU power; 
+ * @param       cpuPowerStatus Upon success, a pointer to a dictionary defining CPU power;
  *              otherwise NULL. Pointer will be populated with a newly created dictionary 
  *              upon successful return. Caller must release dictionary.
  * @result      kIOReturnSuccess, or other error report. Returns kIOReturnNotFound if 

--- a/QuartzCore/CAPackage.h
+++ b/QuartzCore/CAPackage.h
@@ -4,8 +4,8 @@
 API_AVAILABLE(ios(6.0))
 @interface CAPackage : NSObject
 
-@property (readonly) CALayer *rootLayer; 
-@property (getter=isGeometryFlipped, readonly) BOOL geometryFlipped; 
+@property (readonly) CALayer *rootLayer;
+@property (getter=isGeometryFlipped, readonly) BOOL geometryFlipped;
 
 + (instancetype)packageWithContentsOfURL:(NSURL *)url type:(id)type options:(id)options error:(NSError **)error;
 

--- a/SpringBoard/SBWorkspaceTransitionContext.h
+++ b/SpringBoard/SBWorkspaceTransitionContext.h
@@ -3,6 +3,6 @@
 @interface SBWorkspaceTransitionContext : NSObject
 
 @property (nonatomic, copy, readonly) NSSet *entities;
-@property (nonatomic, assign) BOOL animationDisabled; 
+@property (nonatomic, assign) BOOL animationDisabled;
 
 @end

--- a/UIKit/_UIAssetManager.h
+++ b/UIKit/_UIAssetManager.h
@@ -3,9 +3,9 @@
 API_AVAILABLE(ios(7.0))
 @interface _UIAssetManager : NSObject
 
-@property (assign, nonatomic) CGFloat preferredScale;   
+@property (assign, nonatomic) CGFloat preferredScale;
 @property (nonatomic, retain) UITraitCollection *preferredTraitCollection;
-@property (nonatomic, readonly) NSString *carFileName; 
+@property (nonatomic, readonly) NSString *carFileName;
 @property (nonatomic, readonly) NSBundle *bundle;
 
 + (instancetype)assetManagerForBundle:(NSBundle *)bundle;

--- a/installd/MIDaemonConfiguration.h
+++ b/installd/MIDaemonConfiguration.h
@@ -3,8 +3,8 @@
 API_AVAILABLE(ios(13.0))
 @interface MIDaemonConfiguration : MIGlobalConfiguration
 
-@property (nonatomic, readonly) BOOL skipDeviceFamilyCheck; 
-@property (nonatomic, readonly) BOOL skipThinningCheck; 
-@property (nonatomic, readonly) BOOL allowPatchWithoutSinf; 
+@property (nonatomic, readonly) BOOL skipDeviceFamilyCheck;
+@property (nonatomic, readonly) BOOL skipThinningCheck;
+@property (nonatomic, readonly) BOOL allowPatchWithoutSinf;
 
 @end

--- a/openssl/asn1.h
+++ b/openssl/asn1.h
@@ -370,7 +370,7 @@ TYPEDEF_D2I2D_OF(void);
  *      ...
  *      ASN1_ITEM_EXP *iptr;
  *      ...
- * } SOMETHING; 
+ * } SOMETHING;
  *
  * It would be initialised as e.g.:
  *

--- a/openssl/evp.h
+++ b/openssl/evp.h
@@ -546,7 +546,7 @@ void	EVP_MD_CTX_init(EVP_MD_CTX *ctx);
 int	EVP_MD_CTX_cleanup(EVP_MD_CTX *ctx);
 EVP_MD_CTX *EVP_MD_CTX_create(void);
 void	EVP_MD_CTX_destroy(EVP_MD_CTX *ctx);
-int     EVP_MD_CTX_copy_ex(EVP_MD_CTX *out,const EVP_MD_CTX *in);  
+int     EVP_MD_CTX_copy_ex(EVP_MD_CTX *out,const EVP_MD_CTX *in);
 void	EVP_MD_CTX_set_flags(EVP_MD_CTX *ctx, int flags);
 void	EVP_MD_CTX_clear_flags(EVP_MD_CTX *ctx, int flags);
 int 	EVP_MD_CTX_test_flags(const EVP_MD_CTX *ctx,int flags);
@@ -557,7 +557,7 @@ int	EVP_DigestFinal_ex(EVP_MD_CTX *ctx,unsigned char *md,unsigned int *s);
 int	EVP_Digest(const void *data, size_t count,
 		unsigned char *md, unsigned int *size, const EVP_MD *type, ENGINE *impl);
 
-int     EVP_MD_CTX_copy(EVP_MD_CTX *out,const EVP_MD_CTX *in);  
+int     EVP_MD_CTX_copy(EVP_MD_CTX *out,const EVP_MD_CTX *in);
 int	EVP_DigestInit(EVP_MD_CTX *ctx, const EVP_MD *type);
 int	EVP_DigestFinal(EVP_MD_CTX *ctx,unsigned char *md,unsigned int *s);
 

--- a/openssl/pkcs7.h
+++ b/openssl/pkcs7.h
@@ -320,7 +320,7 @@ int PKCS7_add_certificate(PKCS7 *p7, X509 *x509);
 int PKCS7_add_crl(PKCS7 *p7, X509_CRL *x509);
 int PKCS7_content_new(PKCS7 *p7, int nid);
 int PKCS7_dataVerify(X509_STORE *cert_store, X509_STORE_CTX *ctx,
-	BIO *bio, PKCS7 *p7, PKCS7_SIGNER_INFO *si); 
+	BIO *bio, PKCS7 *p7, PKCS7_SIGNER_INFO *si);
 int PKCS7_signatureVerify(BIO *bio, PKCS7 *p7, PKCS7_SIGNER_INFO *si,
 								X509 *x509);
 

--- a/openssl/ssl2.h
+++ b/openssl/ssl2.h
@@ -208,9 +208,9 @@ typedef struct ssl2_state_st
 		unsigned int conn_id_length;
 		unsigned int cert_type;	
 		unsigned int cert_length;
-		unsigned int csl; 
+		unsigned int csl;
 		unsigned int clear;
-		unsigned int enc; 
+		unsigned int enc;
 		unsigned char ccl[SSL2_MAX_CERT_CHALLENGE_LENGTH];
 		unsigned int cipher_spec_length;
 		unsigned int session_id_length;

--- a/openssl/x509v3.h
+++ b/openssl/x509v3.h
@@ -458,9 +458,9 @@ DECLARE_ASN1_FUNCTIONS(BASIC_CONSTRAINTS)
 DECLARE_ASN1_FUNCTIONS(SXNET)
 DECLARE_ASN1_FUNCTIONS(SXNETID)
 
-int SXNET_add_id_asc(SXNET **psx, char *zone, char *user, int userlen); 
-int SXNET_add_id_ulong(SXNET **psx, unsigned long lzone, char *user, int userlen); 
-int SXNET_add_id_INTEGER(SXNET **psx, ASN1_INTEGER *izone, char *user, int userlen); 
+int SXNET_add_id_asc(SXNET **psx, char *zone, char *user, int userlen);
+int SXNET_add_id_ulong(SXNET **psx, unsigned long lzone, char *user, int userlen);
+int SXNET_add_id_INTEGER(SXNET **psx, ASN1_INTEGER *izone, char *user, int userlen);
 
 ASN1_OCTET_STRING *SXNET_get_id_asc(SXNET *sx, char *zone);
 ASN1_OCTET_STRING *SXNET_get_id_ulong(SXNET *sx, unsigned long lzone);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link below to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
…

Checklist
---------
- [x] New code follows the [code rules](https://github.com/theos/headers/blob/master/README.md#code-rules)
- [ ] I've added modulemaps for any new libraries (e.g. see [libactivator/module.modulemap](https://github.com/theos/headers/blob/f3e596d896bae8f07c43cfb00ef55bf6224b4cdc/libactivator/module.modulemap)): it should be possible to `@import MyLibrary;` in ObjC, or `import MyLibrary` in Swift.
- [x] My contribution is code written by myself from reverse-engineered headers, licensed into the Public Domain as per [LICENSE.md](LICENSE.md); or, code written by myself / taken from an existing project, released under an OSI-approved license, and I've added relevant licensing credit to [LICENSE.md](LICENSE.md)


Does this close any currently open issues?
------------------------------------------
…

Any relevant logs, error output, etc?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
**Operating System:** …

**Platform:** …

**Target Platform:** …

**Toolchain Version:** …

**SDK Version:** …
