### PR TITLE
GitHub Action: Test syntax of headers in the repo

### DIFF
--- a/.github/workflows/compile-test.yml
+++ b/.github/workflows/compile-test.yml
@@ -27,9 +27,37 @@ jobs:
 
       - name: Compile All
         run: |
+          UNCHECKED_DIRECTORIES=(
+              "IOKit"
+              "openssl"
+          )
+          UNCHECKED_FILES=(
+              "QuartzCore/QuartzCore-Structs.h" # known to not work
+              "rocketbootstrap/rocketbootstrap_dynamic.h" # noted to not include directly
+              "libundirect/libundirect_hookoverwrite.h" # user's responsibility to include either the base or dynamic header
+          )
+
           HEADER_DIR="headers"
           # cut to drop the leading directory
           for HEADER in $(find "${HEADER_DIR}" -name "*.h" | cut -c"$(( ${#HEADER_DIR} + 2))"-); do
+            IS_UNCHECKED="false"
+            
+            for UNCHECKED_DIRECTORY in "${UNCHECKED_DIRECTORIES[@]}"; do
+                if [[ "${HEADER}" == "${UNCHECKED_DIRECTORY}"/* ]]; then
+                        IS_UNCHECKED="true"
+                        break
+                fi
+            done
+            for UNCHECKED_FILE in "${UNCHECKED_FILES[@]}"; do
+                if [[ "${HEADER}" == "${UNCHECKED_FILE}" ]]; then
+                        IS_UNCHECKED="true"
+                        break
+                fi
+            done
+            if [[ "${IS_UNCHECKED}" == "true" ]]; then
+                continue
+            fi
+            
             COMPILE_FILE="a.m"
             {
               # Eventually we want to not require UIKit, but we're not there yet

--- a/.github/workflows/compile-test.yml
+++ b/.github/workflows/compile-test.yml
@@ -1,0 +1,43 @@
+name: Compile Test
+
+on:
+  push:
+
+jobs:
+  compile-headers:
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ["objective-c", "objective-c++"]
+        cflags: ["", "-fobjc-arc"]
+    steps:
+      - name: Checkout theos/sdks
+        uses: actions/checkout@v3
+        with:
+          repository: theos/sdks
+          ref: fd931ca723ee46994ad9f73c2f0929d1ab9732ca # pinned, should be updated as appropriate
+          path: sdks
+
+      - name: Checkout theos/headers
+        uses: actions/checkout@v3
+        with:
+          path: headers
+
+      - name: Compile All
+        run: |
+          HEADER_DIR="headers"
+          # cut to drop the leading directory
+          for HEADER in $(find "${HEADER_DIR}" -name "*.h" | cut -c"$(( ${#HEADER_DIR} + 2))"-); do
+            COMPILE_FILE="a.m"
+            {
+              # Eventually we want to not require UIKit, but we're not there yet
+              echo "#import <UIKit/UIKit.h>"
+              echo "#import <${HEADER}>"
+              echo "int main() {}"
+            } > "${COMPILE_FILE}"
+            clang -I "${HEADER_DIR}" -isysroot sdks/iPhoneOS14.5.sdk \
+              -target arm64-apple-ios15.4 -arch arm64 \
+              -x "${{ matrix.language }}" ${{ matrix.cflags }} \
+              -fsyntax-only "${COMPILE_FILE}"
+          done

--- a/.github/workflows/compile-test.yml
+++ b/.github/workflows/compile-test.yml
@@ -5,12 +5,13 @@ on:
 
 jobs:
   compile-headers:
-    runs-on: macos-latest
     strategy:
       fail-fast: false
       matrix:
+        runner: ["ubuntu-latest", "macos-latest"]
         language: ["objective-c", "objective-c++"]
         cflags: ["", "-fobjc-arc"]
+    runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout theos/sdks
         uses: actions/checkout@v3

--- a/.github/workflows/compile-test.yml
+++ b/.github/workflows/compile-test.yml
@@ -28,37 +28,32 @@ jobs:
       - name: Compile All
         run: |
           UNCHECKED_DIRECTORIES=(
-              "IOKit"
-              "openssl"
+            "IOKit"
+            "openssl"
           )
           UNCHECKED_FILES=(
-              "QuartzCore/QuartzCore-Structs.h" # known to not work
-              "rocketbootstrap/rocketbootstrap_dynamic.h" # noted to not include directly
-              "libundirect/libundirect_hookoverwrite.h" # user's responsibility to include either the base or dynamic header
+            "QuartzCore/QuartzCore-Structs.h" # known to not work
+            "rocketbootstrap/rocketbootstrap_dynamic.h" # noted to not include directly
+            "libundirect/libundirect_hookoverwrite.h" # user's responsibility to include either the base or dynamic header
           )
-
+          
           HEADER_DIR="headers"
           # cut to drop the leading directory
           for HEADER in $(find "${HEADER_DIR}" -name "*.h" | cut -c"$(( ${#HEADER_DIR} + 2))"-); do
-            IS_UNCHECKED="false"
             
             for UNCHECKED_DIRECTORY in "${UNCHECKED_DIRECTORIES[@]}"; do
-                if [[ "${HEADER}" == "${UNCHECKED_DIRECTORY}"/* ]]; then
-                        IS_UNCHECKED="true"
-                        break
-                fi
+              if [[ "${HEADER}" == "${UNCHECKED_DIRECTORY}"/* ]]; then
+                continue 2
+              fi
             done
-            for UNCHECKED_FILE in "${UNCHECKED_FILES[@]}"; do
-                if [[ "${HEADER}" == "${UNCHECKED_FILE}" ]]; then
-                        IS_UNCHECKED="true"
-                        break
-                fi
-            done
-            if [[ "${IS_UNCHECKED}" == "true" ]]; then
-                continue
-            fi
             
-            COMPILE_FILE="a.m"
+            for UNCHECKED_FILE in "${UNCHECKED_FILES[@]}"; do
+              if [[ "${HEADER}" == "${UNCHECKED_FILE}" ]]; then
+                continue 2
+              fi
+            done
+            
+            COMPILE_FILE="source"
             {
               # Eventually we want to not require UIKit, but we're not there yet
               echo "#import <UIKit/UIKit.h>"

--- a/.github/workflows/compile-test.yml
+++ b/.github/workflows/compile-test.yml
@@ -53,15 +53,13 @@ jobs:
               fi
             done
             
-            COMPILE_FILE="source"
             {
               # Eventually we want to not require UIKit, but we're not there yet
               echo "#import <UIKit/UIKit.h>"
               echo "#import <${HEADER}>"
               echo "int main() {}"
-            } > "${COMPILE_FILE}"
-            clang -I "${HEADER_DIR}" -isysroot sdks/iPhoneOS14.5.sdk \
+            } | clang -I "${HEADER_DIR}" -isysroot sdks/iPhoneOS14.5.sdk \
               -target arm64-apple-ios14.5 -arch arm64 \
               -x "${{ matrix.language }}" ${{ matrix.cflags }} \
-              -fsyntax-only "${COMPILE_FILE}"
+              -fsyntax-only -
           done

--- a/.github/workflows/compile-test.yml
+++ b/.github/workflows/compile-test.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: theos/sdks
-          ref: fd931ca723ee46994ad9f73c2f0929d1ab9732ca # pinned, should be updated as appropriate
+          ref: bb425abf3acae8eac328b828628b82df544d2774 # pinned, should be updated as appropriate
           path: sdks
 
       - name: Checkout theos/headers
@@ -38,7 +38,7 @@ jobs:
               echo "int main() {}"
             } > "${COMPILE_FILE}"
             clang -I "${HEADER_DIR}" -isysroot sdks/iPhoneOS14.5.sdk \
-              -target arm64-apple-ios15.4 -arch arm64 \
+              -target arm64-apple-ios14.5 -arch arm64 \
               -x "${{ matrix.language }}" ${{ matrix.cflags }} \
               -fsyntax-only "${COMPILE_FILE}"
           done


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link below to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------

The contents of this PR adds a GitHub Action that create a blank file, imports a single header, and then tries to verify the syntax stage of compiling with `clang`.

The above action is completed in a matrix with the following configurations:
Ubuntu and macOS, each with Obj-C and Obj-C++, each with ARC enabled and not.

See the 'relevant logs' section below to view these exact configurations.

Does this close any currently open issues?
------------------------------------------

No.

Any relevant logs, error output, etc?
-------------------------------------
See jobs in https://github.com/leptos-null/theos-headers/actions/runs/4844610103

Any other comments?
-------------------

The `IOKit` and `openssl` directories are ignored because they have too many errors.

Where has this been tested?
---------------------------
**Operating System:** Ubuntu, macOS

**Platform:** ...

**Target Platform:** iOS

**Toolchain Version:** ...

**SDK Version:** iOS 14.5
