### PR TITLE
[LowPowerMode] Added _PLLowPowerMode header (iOS 15+)

### DIFF
--- a/LowPowerMode/_PLLowPowerMode.h
+++ b/LowPowerMode/_PLLowPowerMode.h
@@ -1,0 +1,18 @@
+#import <Foundation/Foundation.h>
+
+static NSString *const kPMLPMSourceSpringBoardAlert = @"SpringBoard";
+static NSString *const kPMLPMSourceReenableBulletin = @"Reenable";
+static NSString *const kPMLPMSourceControlCenter = @"ControlCenter";
+static NSString *const kPMLPMSourceSettings = @"Settings";
+static NSString *const kPMLPMSourceSiri = @"Siri";
+static NSString *const kPMLPMSourceLostMode = @"LostMode";
+static NSString *const kPMLPMSourceSystemDisable = @"SystemDisable";
+
+
+API_AVAILABLE(ios(15.0))
+@interface _PLLowPowerMode : NSObject
++ (instancetype)sharedInstance;
+- (NSInteger)getPowerMode;
+- (void)setPowerMode:(NSInteger)powerMode fromSource:(NSString *)source;
+- (void)setPowerMode:(NSInteger)powerMode fromSource:(NSString *)source withCompletion:(void (^)(BOOL success, NSError *error))completion;
+@end


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link below to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
…

Checklist
---------
- [ ] New code follows the [code rules](https://github.com/theos/headers/blob/master/README.md#code-rules)
- [ ] I've added modulemaps for any new libraries (e.g. see [libactivator/module.modulemap](https://github.com/theos/headers/blob/f3e596d896bae8f07c43cfb00ef55bf6224b4cdc/libactivator/module.modulemap)): it should be possible to `@import MyLibrary;` in ObjC, or `import MyLibrary` in Swift.
- [ ] My contribution is code written by myself from reverse-engineered headers, licensed into the Public Domain as per [LICENSE.md](LICENSE.md); or, code written by myself / taken from an existing project, released under an OSI-approved license, and I've added relevant licensing credit to [LICENSE.md](LICENSE.md)


Does this close any currently open issues?
------------------------------------------
…

Any relevant logs, error output, etc?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
**Operating System:** …

**Platform:** …

**Target Platform:** …

**Toolchain Version:** …

**SDK Version:** …
