### PR TITLE
[libundirect] Updated libundirect headers to version 1.1.4

### DIFF
--- a/libundirect/libundirect.h
+++ b/libundirect/libundirect.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021 Lars Fröder
+// Copyright (c) 2020-2022 Lars Fröder
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -40,6 +40,15 @@ void* libundirect_dsc_find(NSString* imageName, Class _class, SEL selector);
 
 // find a direct method inside dyld_shared_cache by it's name and rebind it (convenience)
 void libundirect_dsc_rebind(NSString* imageName, Class _class, SEL selector, const char* format);
+
+// instead of directly hooking, make all libundirect_MSHookMessageEx calls add to a batch queue
+void libundirect_startBatchHooks(void);
+
+// apply all hooks in batch queue in one shot using libhooker API if it exists
+void libundirect_applyBatchHooks(void);
+
+// apply all hooks in batch queue in one shot together with passed additional ones using libhooker API if it exists
+void libundirect_applyBatchHooksAndAdditional(const struct LHFunctionHook* additionalHooks, NSUInteger additionalCount);
 
 // selectors that failed to be added
 NSArray* libundirect_failedSelectors();

--- a/libundirect/libundirect_dynamic.h
+++ b/libundirect/libundirect_dynamic.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021 Lars Fröder
+// Copyright (c) 2020-2022 Lars Fröder
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -10,14 +10,17 @@
 // The above copyright notice and this permission notice shall be included in all
 // copies or substantial portions of the Software.
 
+#import <objc/objc.h>
+#import <sys/unistd.h>
 #import <dlfcn.h>
-#import <Foundation/Foundation.h>
 #import <substrate.h>
+#import <libhooker/libhooker.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+#define LU_ROOT_PATH_C(cPath) (access(cPath, F_OK) == 0) ? cPath : "/var/jb" cPath
 
 // dynamic header for when you don't want to link against libundirect
 // for documentation, check out the non-dynamic header
@@ -33,7 +36,7 @@ static void libundirect_MSHookMessageEx(Class _class, SEL message, IMP hook, IMP
 	static void (*impl_libundirect_MSHookMessageEx)(Class, SEL, IMP, IMP *);
 	if(!impl_libundirect_MSHookMessageEx)
 	{
-		void* handle = dlopen("/usr/lib/libundirect.dylib", RTLD_LAZY);
+		void* handle = dlopen(LU_ROOT_PATH_C("/usr/lib/libundirect.dylib"), RTLD_LAZY);
 		impl_libundirect_MSHookMessageEx = (void (*)(Class, SEL, IMP, IMP *))dlsym(handle, "libundirect_MSHookMessageEx");
 	}
 	if(impl_libundirect_MSHookMessageEx)
@@ -52,7 +55,7 @@ static void libundirect_rebind(void* directPtr, Class _class, SEL selector, cons
 	static void (*impl_libundirect_rebind)(void*, Class, SEL, const char*);
 	if(!impl_libundirect_rebind)
 	{
-		void* handle = dlopen("/usr/lib/libundirect.dylib", RTLD_LAZY);
+		void* handle = dlopen(LU_ROOT_PATH_C("/usr/lib/libundirect.dylib"), RTLD_LAZY);
 		impl_libundirect_rebind = (void (*)(void*, Class, SEL, const char*))dlsym(handle, "libundirect_rebind");
 	}
 	if(impl_libundirect_rebind)
@@ -67,7 +70,7 @@ static void* libundirect_seek_back(void* startPtr, unsigned char toByte, unsigne
 	static void* (*impl_libundirect_seek_back)(void*, unsigned char, unsigned int);
 	if(!impl_libundirect_seek_back)
 	{
-		void* handle = dlopen("/usr/lib/libundirect.dylib", RTLD_LAZY);
+		void* handle = dlopen(LU_ROOT_PATH_C("/usr/lib/libundirect.dylib"), RTLD_LAZY);
 		impl_libundirect_seek_back = (void* (*)(void*, unsigned char, unsigned int))dlsym(handle, "libundirect_seek_back");
 	}
 	if(impl_libundirect_seek_back)
@@ -83,7 +86,7 @@ static void* libundirect_find_with_options_and_mask(NSString* imageName, unsigne
 	static void* (*impl_libundirect_find_with_options_and_mask)(NSString*, unsigned char*, unsigned char*, size_t, unsigned char, unsigned int, libundirect_find_options_t);
 	if(!impl_libundirect_find_with_options_and_mask)
 	{
-		void* handle = dlopen("/usr/lib/libundirect.dylib", RTLD_LAZY);
+		void* handle = dlopen(LU_ROOT_PATH_C("/usr/lib/libundirect.dylib"), RTLD_LAZY);
 		impl_libundirect_find_with_options_and_mask = (void* (*)(NSString*, unsigned char*, unsigned char*, size_t, unsigned char, unsigned int, libundirect_find_options_t))dlsym(handle, "libundirect_find_with_options_and_mask");
 	}
 	if(impl_libundirect_find_with_options_and_mask)
@@ -99,7 +102,7 @@ static void* libundirect_find_with_options(NSString* imageName, unsigned char* b
 	static void* (*impl_libundirect_find_with_options)(NSString*, unsigned char*, size_t, unsigned char, unsigned int, libundirect_find_options_t);
 	if(!impl_libundirect_find_with_options)
 	{
-		void* handle = dlopen("/usr/lib/libundirect.dylib", RTLD_LAZY);
+		void* handle = dlopen(LU_ROOT_PATH_C("/usr/lib/libundirect.dylib"), RTLD_LAZY);
 		impl_libundirect_find_with_options = (void* (*)(NSString*, unsigned char*, size_t, unsigned char, unsigned int, libundirect_find_options_t))dlsym(handle, "libundirect_find_with_options");
 	}
 	if(impl_libundirect_find_with_options)
@@ -115,7 +118,7 @@ static void* libundirect_find(NSString* imageName, unsigned char* bytesToSearch,
 	static void* (*impl_libundirect_find)(NSString*, unsigned char*, size_t, unsigned char);
 	if(!impl_libundirect_find)
 	{
-		void* handle = dlopen("/usr/lib/libundirect.dylib", RTLD_LAZY);
+		void* handle = dlopen(LU_ROOT_PATH_C("/usr/lib/libundirect.dylib"), RTLD_LAZY);
 		impl_libundirect_find = (void* (*)(NSString*, unsigned char*, size_t, unsigned char))dlsym(handle, "libundirect_find");
 	}
 	if(impl_libundirect_find)
@@ -131,7 +134,7 @@ static void* libundirect_dsc_find(NSString* imageName, Class _class, SEL selecto
 	static void* (*impl_libundirect_dsc_find)(NSString*, Class, SEL);
 	if(!impl_libundirect_dsc_find)
 	{
-		void* handle = dlopen("/usr/lib/libundirect.dylib", RTLD_LAZY);
+		void* handle = dlopen(LU_ROOT_PATH_C("/usr/lib/libundirect.dylib"), RTLD_LAZY);
 		impl_libundirect_dsc_find = (void* (*)(NSString*, Class, SEL))dlsym(handle, "libundirect_dsc_find");
 	}
 	if(impl_libundirect_dsc_find)
@@ -147,7 +150,7 @@ static void libundirect_dsc_rebind(NSString* imageName, Class _class, SEL select
 	static void (*impl_libundirect_dsc_rebind)(NSString*, Class, SEL, const char*);
 	if(!impl_libundirect_dsc_rebind)
 	{
-		void* handle = dlopen("/usr/lib/libundirect.dylib", RTLD_LAZY);
+		void* handle = dlopen(LU_ROOT_PATH_C("/usr/lib/libundirect.dylib"), RTLD_LAZY);
 		impl_libundirect_dsc_rebind = (void (*)(NSString*, Class, SEL, const char*))dlsym(handle, "libundirect_dsc_rebind");
 	}
 	if(impl_libundirect_dsc_rebind)
@@ -162,7 +165,7 @@ static NSArray* libundirect_failedSelectors()
 	static NSArray* (*impl_libundirect_failedSelectors)();
 	if(!impl_libundirect_failedSelectors)
 	{
-		void* handle = dlopen("/usr/lib/libundirect.dylib", RTLD_LAZY);
+		void* handle = dlopen(LU_ROOT_PATH_C("/usr/lib/libundirect.dylib"), RTLD_LAZY);
 		impl_libundirect_failedSelectors = (NSArray* (*)(void))dlsym(handle, "libundirect_failedSelectors");
 	}
 	if(impl_libundirect_failedSelectors)
@@ -170,6 +173,51 @@ static NSArray* libundirect_failedSelectors()
 		return impl_libundirect_failedSelectors();
 	}
 	return (NSArray*)nil;
+}
+
+__attribute__((unused))
+static void libundirect_startBatchHooks(void)
+{
+	static void (*impl_libundirect_startBatchHooks)();
+	if(!impl_libundirect_startBatchHooks)
+	{
+		void* handle = dlopen(LU_ROOT_PATH_C("/usr/lib/libundirect.dylib"), RTLD_LAZY);
+		impl_libundirect_startBatchHooks = (void (*)(void))dlsym(handle, "libundirect_startBatchHooks");
+	}
+	if(impl_libundirect_startBatchHooks)
+	{
+		impl_libundirect_startBatchHooks();
+	}
+}
+
+__attribute__((unused))
+static void libundirect_applyBatchHooksAndAdditional(const struct LHFunctionHook* additionalHooks, NSUInteger additionalCount)
+{
+	static void (*impl_libundirect_applyBatchHooksAndAdditional)(const struct LHFunctionHook*, NSUInteger);
+	if(!impl_libundirect_applyBatchHooksAndAdditional)
+	{
+		void* handle = dlopen(LU_ROOT_PATH_C("/usr/lib/libundirect.dylib"), RTLD_LAZY);
+		impl_libundirect_applyBatchHooksAndAdditional = (void (*)(const struct LHFunctionHook*, NSUInteger))dlsym(handle, "libundirect_applyBatchHooksAndAdditional");
+	}
+	if(impl_libundirect_applyBatchHooksAndAdditional)
+	{
+		impl_libundirect_applyBatchHooksAndAdditional(additionalHooks, additionalCount);
+	}
+}
+
+__attribute__((unused))
+static void libundirect_applyBatchHooks()
+{
+	static void (*impl_libundirect_applyBatchHooks)();
+	if(!impl_libundirect_applyBatchHooks)
+	{
+		void* handle = dlopen(LU_ROOT_PATH_C("/usr/lib/libundirect.dylib"), RTLD_LAZY);
+		impl_libundirect_applyBatchHooks = (void (*)(void))dlsym(handle, "libundirect_failedSelectors");
+	}
+	if(impl_libundirect_applyBatchHooks)
+	{
+		return impl_libundirect_applyBatchHooks();
+	}
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link below to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
…

Checklist
---------
- [ ] New code follows the [code rules](https://github.com/theos/headers/blob/master/README.md#code-rules)
- [ ] I've added modulemaps for any new libraries (e.g. see [libactivator/module.modulemap](https://github.com/theos/headers/blob/f3e596d896bae8f07c43cfb00ef55bf6224b4cdc/libactivator/module.modulemap)): it should be possible to `@import MyLibrary;` in ObjC, or `import MyLibrary` in Swift.
- [ ] My contribution is code written by myself from reverse-engineered headers, licensed into the Public Domain as per [LICENSE.md](LICENSE.md); or, code written by myself / taken from an existing project, released under an OSI-approved license, and I've added relevant licensing credit to [LICENSE.md](LICENSE.md)


Does this close any currently open issues?
------------------------------------------
…

Any relevant logs, error output, etc?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
**Operating System:** …

**Platform:** …

**Target Platform:** …

**Toolchain Version:** …

**SDK Version:** …
