### PR TITLE
Add rootless preprocessor macros

### DIFF
--- a/rootless.h
+++ b/rootless.h
@@ -1,0 +1,11 @@
+#ifdef THEOS_PACKAGE_INSTALL_PREFIX
+#define ROOT_PATH(cPath) THEOS_PACKAGE_INSTALL_PREFIX cPath
+#define ROOT_PATH_NS(path) @THEOS_PACKAGE_INSTALL_PREFIX path
+#define ROOT_PATH_NS_VAR(path) [@THEOS_PACKAGE_INSTALL_PREFIX stringByAppendingPathComponent:path]
+#define ROOT_PATH_VAR(cPath) ROOT_PATH_NS_VAR(@cPath).fileSystemRepresentation
+#else
+#define ROOT_PATH(cPath) cPath
+#define ROOT_PATH_NS(path) path
+#define ROOT_PATH_NS_VAR(path) path
+#define ROOT_PATH_VAR(cPath) cPath
+#endif


### PR DESCRIPTION
Rootless preprocessor macros that handle automatic conversion of paths to `/var/jb` only when building for rootless.