### PR TITLE
[version] Added CoreFoundation versions for iOS 16.0 / 16.1 / 16.4

### DIFF
--- a/version.h
+++ b/version.h
@@ -64,6 +64,9 @@
  * 15.2     1856.105
  * 15.3     1856.105
  * 15.4     1858.112
+ * 16.0     1946.102
+ * 16.1     1953.1
+ * 16.4     1971
  *
  * Reference:
  * https://iphonedev.wiki/index.php/CoreFoundation.framework#Versions

--- a/version.h
+++ b/version.h
@@ -295,6 +295,18 @@
 #define kCFCoreFoundationVersionNumber_iOS_15_4 1858.112
 #endif
 
+#ifndef kCFCoreFoundationVersionNumber_iOS_16_0
+#define kCFCoreFoundationVersionNumber_iOS_16_0 1946.102
+#endif
+
+#ifndef kCFCoreFoundationVersionNumber_iOS_16_1
+#define kCFCoreFoundationVersionNumber_iOS_16_1 1953.1
+#endif
+
+#ifndef kCFCoreFoundationVersionNumber_iOS_16_4
+#define kCFCoreFoundationVersionNumber_iOS_16_4 1971
+#endif
+
 #ifndef kCFCoreFoundationVersionNumber10_10
 #define kCFCoreFoundationVersionNumber10_10 1151.16
 #endif


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link below to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Added CoreFoundation versions for iOS 16.0 / 16.1 / 16.4

Checklist
---------
- [ ] New code follows the [code rules](https://github.com/theos/headers/blob/master/README.md#code-rules)
- [ ] I've added modulemaps for any new libraries (e.g. see [libactivator/module.modulemap](https://github.com/theos/headers/blob/f3e596d896bae8f07c43cfb00ef55bf6224b4cdc/libactivator/module.modulemap)): it should be possible to `@import MyLibrary;` in ObjC, or `import MyLibrary` in Swift.
- [ ] My contribution is code written by myself from reverse-engineered headers, licensed into the Public Domain as per [LICENSE.md](LICENSE.md); or, code written by myself / taken from an existing project, released under an OSI-approved license, and I've added relevant licensing credit to [LICENSE.md](LICENSE.md)


Does this close any currently open issues?
------------------------------------------
…

Any relevant logs, error output, etc?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
**Operating System:** …

**Platform:** …

**Target Platform:** …

**Toolchain Version:** …

**SDK Version:** …
