### PR TITLE
Clean up rootless.h, add optional Xina compatibility

### DIFF
--- a/rootless.h
+++ b/rootless.h
@@ -1,7 +1,7 @@
 #ifdef XINA_SUPPORT // Only define this for rootful compilations that need support for xina
 #define ROOT_PATH(cPath) [[NSFileManager defaultManager] fileExistsAtPath:@"/var/LIY"] ? "/var/jb" cPath : cPath
-#define ROOT_PATH_NS(path) ([[NSFileManager defaultManager] fileExistsAtPath:@"/var/LIY"] ? [@"/var/jb" stringByAppendingPathComponent:path] : path )
-#define ROOT_PATH_NS_VAR ROOT_PATH_NS
+#define ROOT_PATH_NS(path) [[NSFileManager defaultManager] fileExistsAtPath:@"/var/LIY"] ? @"/var/jb" path : path
+#define ROOT_PATH_NS_VAR [[NSFileManager defaultManager] fileExistsAtPath:@"/var/LIY"] ? [@"/var/jb" stringByAppendingPathComponent:path] : path
 #define ROOT_PATH_VAR(cPath)(ROOT_PATH_NS([NSString stringWithUTF8String:cPath]).fileSystemRepresentation)
 #else
 #define ROOT_PATH(cPath) THEOS_PACKAGE_INSTALL_PREFIX cPath

--- a/rootless.h
+++ b/rootless.h
@@ -1,11 +1,24 @@
+#include <sys/syslimits.h>
+#include <unistd.h>
+
 #ifdef XINA_SUPPORT // Only define this for rootful compilations that need support for xina
-#define ROOT_PATH(cPath) [[NSFileManager defaultManager] fileExistsAtPath:@"/var/LIY"] ? "/var/jb" cPath : cPath
-#define ROOT_PATH_NS(path) [[NSFileManager defaultManager] fileExistsAtPath:@"/var/LIY"] ? @"/var/jb" path : path
-#define ROOT_PATH_NS_VAR [[NSFileManager defaultManager] fileExistsAtPath:@"/var/LIY"] ? [@"/var/jb" stringByAppendingPathComponent:path] : path
-#define ROOT_PATH_VAR(cPath)(ROOT_PATH_NS([NSString stringWithUTF8String:cPath]).fileSystemRepresentation)
+#define ROOT_PATH(cPath) !access("/var/LIY", F_OK) ? "/var/jb" cPath : cPath
+#define ROOT_PATH_NS(path) !access("/var/LIY", F_OK) ? @"/var/jb" path : path
+#define ROOT_PATH_NS_VAR !access("/var/LIY", F_OK) ? [@"/var/jb" stringByAppendingPathComponent:path] : path
+#define ROOT_PATH_VAR(path) !access("/var/LIY", F_OK) ? ({ \
+	char outPath[PATH_MAX]; \
+	strlcpy(outPath, "/var/jb", PATH_MAX); \
+	strlcat(outPath, path, PATH_MAX); \
+	outPath; \
+}) : path
 #else
 #define ROOT_PATH(cPath) THEOS_PACKAGE_INSTALL_PREFIX cPath
 #define ROOT_PATH_NS(path) @THEOS_PACKAGE_INSTALL_PREFIX path
 #define ROOT_PATH_NS_VAR(path) [@THEOS_PACKAGE_INSTALL_PREFIX stringByAppendingPathComponent:path]
-#define ROOT_PATH_VAR(cPath) ROOT_PATH_NS_VAR(@cPath).fileSystemRepresentation
+#define ROOT_PATH_VAR(path) sizeof(THEOS_PACKAGE_INSTALL_PREFIX) > 1 ? ({ \
+    char outPath[PATH_MAX]; \
+    strlcpy(outPath, THEOS_PACKAGE_INSTALL_PREFIX, PATH_MAX); \
+	strlcat(outPath, path, PATH_MAX); \
+    outPath; \
+}) : path
 #endif

--- a/rootless.h
+++ b/rootless.h
@@ -1,11 +1,11 @@
-#ifdef THEOS_PACKAGE_INSTALL_PREFIX
+#ifdef XINA_SUPPORT // Only define this for rootful compilations that need support for xina
+#define ROOT_PATH(cPath) [[NSFileManager defaultManager] fileExistsAtPath:@"/var/LIY"] ? "/var/jb" cPath : cPath
+#define ROOT_PATH_NS(path) ([[NSFileManager defaultManager] fileExistsAtPath:@"/var/LIY"] ? [@"/var/jb" stringByAppendingPathComponent:path] : path )
+#define ROOT_PATH_NS_VAR ROOT_PATH_NS
+#define ROOT_PATH_VAR(cPath)(ROOT_PATH_NS([NSString stringWithUTF8String:cPath]).fileSystemRepresentation)
+#else
 #define ROOT_PATH(cPath) THEOS_PACKAGE_INSTALL_PREFIX cPath
 #define ROOT_PATH_NS(path) @THEOS_PACKAGE_INSTALL_PREFIX path
 #define ROOT_PATH_NS_VAR(path) [@THEOS_PACKAGE_INSTALL_PREFIX stringByAppendingPathComponent:path]
 #define ROOT_PATH_VAR(cPath) ROOT_PATH_NS_VAR(@cPath).fileSystemRepresentation
-#else
-#define ROOT_PATH(cPath) cPath
-#define ROOT_PATH_NS(path) path
-#define ROOT_PATH_NS_VAR(path) path
-#define ROOT_PATH_VAR(cPath) cPath
 #endif


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This removes the code checking whether `THEOS_PACKAGE_INSTALL_PREFIX` is define, as this is now always defined.
Additionally it introduces backwards support for xina with the define `XINA_SUPPORT` that a dev can set inside the Makefile if Xina support is desired. Note that this should only be set for rootful builds.