### PR TITLE
Import and forward-declare classes as needed to compile headers

### DIFF
--- a/BulletinBoard/BBBulletin.h
+++ b/BulletinBoard/BBBulletin.h
@@ -1,6 +1,6 @@
 #import <AddressBook/AddressBook.h>
 
-@class BBAction, BBSectionIcon, BBSectionParameters, BBSectionSubtypeParameters;
+@class BBAction, BBContent, BBSectionIcon, BBSectionParameters, BBSectionSubtypeParameters;
 
 typedef NS_ENUM(NSUInteger, BBBulletinAccessoryStyle) {
 	BBBulletinAccessoryStyleNone,

--- a/Contacts/CNContact+Private.h
+++ b/Contacts/CNContact+Private.h
@@ -1,4 +1,6 @@
-@class CNEmailAddressContactPredicate, CNPhoneNumberContactPredicate;
+#import <Contacts/CNContact.h>
+
+@class CNEmailAddressContactPredicate, CNPhoneNumberContactPredicate, CNPhoneNumber;
 
 @interface CNContact (Private)
 

--- a/Contacts/CNContactFormatter+Private.h
+++ b/Contacts/CNContactFormatter+Private.h
@@ -1,3 +1,5 @@
+#import <Contacts/CNContactFormatter.h>
+
 @interface CNContactFormatter (Private)
 
 - (NSString *)shortNameForContact:(CNContact *)contact attributes:(NSDictionary *)attributes;

--- a/Contacts/CNPhoneNumber+Private.h
+++ b/Contacts/CNPhoneNumber+Private.h
@@ -1,3 +1,5 @@
+#import <Contacts/CNPhoneNumber.h>
+
 @interface CNPhoneNumber (Private)
 
 @property (nonatomic, readonly, copy) NSString *countryCode;

--- a/ControlCenterUIKit/CCUILabeledRoundButton.h
+++ b/ControlCenterUIKit/CCUILabeledRoundButton.h
@@ -1,6 +1,5 @@
-#import <UIKit/UKit.h>
+#import <UIKit/UIKit.h>
 #import <Foundation/Foundation.h>
-#import <CoreHaptics/CoreGraphics.h>
 #import "CCUICAPackageDescription.h"
 #import "CCUIRoundButton.h"
 

--- a/MapKit/MKMapItem+Private.h
+++ b/MapKit/MKMapItem+Private.h
@@ -1,3 +1,5 @@
+#import <MapKit/MKMapItem.h>
+
 @class MKPlacemark;
 
 typedef void (^MKMapItemItemsFromHandleCompletion)(NSArray <NSURL *> *items);

--- a/UserNotificationsUIKit/NCNotificationRequest+Additions.h
+++ b/UserNotificationsUIKit/NCNotificationRequest+Additions.h
@@ -1,3 +1,5 @@
+#import <UserNotificationsKit/NCNotificationRequest.h>
+
 @class BBBulletin;
 
 @interface NCNotificationRequest (Additions)


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

Enables more headers to be imported by themselves.

Checklist
---------
- [x] New code follows the [code rules](https://github.com/theos/headers/blob/master/README.md#code-rules)
- [x] I've added modulemaps for any new libraries (e.g. see [libactivator/module.modulemap](https://github.com/theos/headers/blob/f3e596d896bae8f07c43cfb00ef55bf6224b4cdc/libactivator/module.modulemap)): it should be possible to `@import MyLibrary;` in ObjC, or `import MyLibrary` in Swift.
- [x] My contribution is code written by myself from reverse-engineered headers, licensed into the Public Domain as per [LICENSE.md](LICENSE.md); or, code written by myself / taken from an existing project, released under an OSI-approved license, and I've added relevant licensing credit to [LICENSE.md](LICENSE.md)


Does this close any currently open issues?
------------------------------------------
…

Any relevant logs, error output, etc?
-------------------------------------
…

Any other comments?
-------------------
This unblocks #72 

Where has this been tested?
---------------------------
**Operating System:** Ubuntu, macOS

**Platform:** …

**Target Platform:** iOS

**Toolchain Version:** …

**SDK Version:** iOS 14.5
