### PR TITLE
More methods for FBSSystemService.h

### DIFF
--- a/FrontBoardServices/FBSSystemService.h
+++ b/FrontBoardServices/FBSSystemService.h
@@ -16,7 +16,7 @@ FOUNDATION_EXPORT NSString *const FBSOpenApplicationOptionKeyActivateSuspended;
 - (void)sendActions:(NSSet <BSAction *> *)actions withResult:(FBSSystemServiceResultCallback)result;
 - (void)openURL:(NSURL *)url application:(NSString *)bundleIdentifier options:(NSDictionary <NSString *, id> *)options clientPort:(mach_port_t)clientPort withResult:(FBSSystemServiceResultCallback)callback;
 - (void)openApplication:(NSString *)app options:(NSDictionary *)options withResult:(void (^)(void))result;
-- (void)shutdown;
-- (void)reboot;
+- (void)shutdown API_AVAILABLE(ios(8.0));
+- (void)reboot API_AVAILABLE(ios(8.0));
 
 @end

--- a/FrontBoardServices/FBSSystemService.h
+++ b/FrontBoardServices/FBSSystemService.h
@@ -16,5 +16,7 @@ FOUNDATION_EXPORT NSString *const FBSOpenApplicationOptionKeyActivateSuspended;
 - (void)sendActions:(NSSet <BSAction *> *)actions withResult:(FBSSystemServiceResultCallback)result;
 - (void)openURL:(NSURL *)url application:(NSString *)bundleIdentifier options:(NSDictionary <NSString *, id> *)options clientPort:(mach_port_t)clientPort withResult:(FBSSystemServiceResultCallback)callback;
 - (void)openApplication:(NSString *)app options:(NSDictionary *)options withResult:(void (^)(void))result;
+- (void)shutdown;
+- (void)reboot;
 
 @end


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link below to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Adds extra methods to FBSSystemService.h

Checklist
---------
- [x] New code follows the [code rules](https://github.com/theos/headers/blob/master/README.md#code-rules)
- [x] I've added modulemaps for any new libraries (e.g. see [libactivator/module.modulemap](https://github.com/theos/headers/blob/f3e596d896bae8f07c43cfb00ef55bf6224b4cdc/libactivator/module.modulemap)): it should be possible to `@import MyLibrary;` in ObjC, or `import MyLibrary` in Swift.
- [x] My contribution is code written by myself from reverse-engineered headers, licensed into the Public Domain as per [LICENSE.md](LICENSE.md); or, code written by myself / taken from an existing project, released under an OSI-approved license, and I've added relevant licensing credit to [LICENSE.md](LICENSE.md)


Does this close any currently open issues?
------------------------------------------
…

Any relevant logs, error output, etc?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
**Operating System:** …

**Platform:** …

**Target Platform:** …

**Toolchain Version:** …

**SDK Version:** …
