### PR TITLE
[rootless] Remove macro support for non-literals, add comment

### DIFF
--- a/rootless.h
+++ b/rootless.h
@@ -14,6 +14,12 @@
 // use the `THEOS_PACKAGE_INSTALL_PREFIX` directly.
 // In C, `strlcpy` and `strlcat` may be used to first copy `THEOS_PACKAGE_INSTALL_PREFIX`
 // into a buffer, followed by the path variable.
+// For example:
+//   const char *inputPath;    // the file path
+//   char *outputPath;         // the file path with the prefix prepended
+//   const size_t outputSize;  // size of the outputPath
+//   strlcpy(outputPath, THEOS_PACKAGE_INSTALL_PREFIX, outputSize);
+//   strlcat(outputPath, inputPath, outputSize);
 
 #ifdef XINA_SUPPORT // Only define this for rootful compilations that need support for xina
 #include <unistd.h> /* for access(2) */

--- a/rootless.h
+++ b/rootless.h
@@ -7,10 +7,11 @@
 //     `cPath` is a C string literal such as "/Library"
 //   ROOT_PATH_NS(path)
 //     `path` is an NSString literal such as @"/Library"
+//   ROOT_PATH_NS_VAR(path)
+//     `path` is an NSString variable
 //
 // If you need to append a variable path to the install prefix (i.e. not a string literal)
-// use the `THEOS_PACKAGE_INSTALL_PREFIX` directly. In Objective-C,
-// `[@THEOS_PACKAGE_INSTALL_PREFIX stringByAppendingPathComponent:path]` may be used.
+// use the `THEOS_PACKAGE_INSTALL_PREFIX` directly.
 // In C, `strlcpy` and `strlcat` may be used to first copy `THEOS_PACKAGE_INSTALL_PREFIX`
 // into a buffer, followed by the path variable.
 
@@ -19,7 +20,9 @@
 
 #define ROOT_PATH(cPath) !access("/var/LIY", F_OK) ? "/var/jb" cPath : cPath
 #define ROOT_PATH_NS(path) !access("/var/LIY", F_OK) ? @"/var/jb" path : path
+#define ROOT_PATH_NS_VAR(path) !access("/var/LIY", F_OK) ? [@"/var/jb" stringByAppendingPathComponent:path] : path
 #else
 #define ROOT_PATH(cPath) THEOS_PACKAGE_INSTALL_PREFIX cPath
 #define ROOT_PATH_NS(path) @THEOS_PACKAGE_INSTALL_PREFIX path
+#define ROOT_PATH_NS_VAR(path) [@THEOS_PACKAGE_INSTALL_PREFIX stringByAppendingPathComponent:path]
 #endif

--- a/rootless.h
+++ b/rootless.h
@@ -1,24 +1,25 @@
-#include <sys/syslimits.h>
-#include <unistd.h>
+#ifndef THEOS_PACKAGE_INSTALL_PREFIX
+#define THEOS_PACKAGE_INSTALL_PREFIX ""
+#endif
+
+// Function-like macros:
+//   ROOT_PATH(cPath)
+//     `cPath` is a C string literal such as "/Library"
+//   ROOT_PATH_NS(path)
+//     `path` is an NSString literal such as @"/Library"
+//
+// If you need to append a variable path to the install prefix (i.e. not a string literal)
+// use the `THEOS_PACKAGE_INSTALL_PREFIX` directly. In Objective-C,
+// `[@THEOS_PACKAGE_INSTALL_PREFIX stringByAppendingPathComponent:path]` may be used.
+// In C, `strlcpy` and `strlcat` may be used to first copy `THEOS_PACKAGE_INSTALL_PREFIX`
+// into a buffer, followed by the path variable.
 
 #ifdef XINA_SUPPORT // Only define this for rootful compilations that need support for xina
+#include <unistd.h> /* for access(2) */
+
 #define ROOT_PATH(cPath) !access("/var/LIY", F_OK) ? "/var/jb" cPath : cPath
 #define ROOT_PATH_NS(path) !access("/var/LIY", F_OK) ? @"/var/jb" path : path
-#define ROOT_PATH_NS_VAR(path) !access("/var/LIY", F_OK) ? [@"/var/jb" stringByAppendingPathComponent:path] : path
-#define ROOT_PATH_VAR(path) !access("/var/LIY", F_OK) ? ({ \
-	char outPath[PATH_MAX]; \
-	strlcpy(outPath, "/var/jb", PATH_MAX); \
-	strlcat(outPath, path, PATH_MAX); \
-	outPath; \
-}) : path
 #else
 #define ROOT_PATH(cPath) THEOS_PACKAGE_INSTALL_PREFIX cPath
 #define ROOT_PATH_NS(path) @THEOS_PACKAGE_INSTALL_PREFIX path
-#define ROOT_PATH_NS_VAR(path) [@THEOS_PACKAGE_INSTALL_PREFIX stringByAppendingPathComponent:path]
-#define ROOT_PATH_VAR(path) sizeof(THEOS_PACKAGE_INSTALL_PREFIX) > 1 ? ({ \
-    char outPath[PATH_MAX]; \
-    strlcpy(outPath, THEOS_PACKAGE_INSTALL_PREFIX, PATH_MAX); \
-	strlcat(outPath, path, PATH_MAX); \
-    outPath; \
-}) : path
 #endif


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

Adds a definition for `THEOS_PACKAGE_INSTALL_PREFIX` to empty string if it is not already defined (for example, when importing in Xcode).

Removes `ROOT_PATH_NS_VAR` and `ROOT_PATH_VAR`. These were troublesome macros, because it was difficult to manage the returned memory.

For example, the value provided by `ROOT_PATH_VAR` currently is undefined (given that the implementation uses `{}` which results in the variable going out of scope, allowing the compiler to re-claim the memory). @opa334 [suggested](https://github.com/theos/headers/pull/81#issuecomment-1613650204) in #81 to use [`alloca`](https://stackoverflow.com/a/2318448) to achieve the same goal. Even if we used [`__builtin_alloca`](https://clang.llvm.org/docs/LanguageExtensions.html#builtin-alloca), it is not immediately clear to the caller that this value is scoped to the function and may not be used as a return value.

On second thought, `ROOT_PATH_NS_VAR` probably matches developer expectations, but this is still unclear in non-ARC code.

In summary:

1. The use of these macros are error-prune
2. The theoretical usage of these macros are severely limited. Mostly, programs either have a path they want to reference as a literal, or they get a path from another function which should have produced a valid path in the first place.
3. Writing the correct code using `THEOS_PACKAGE_INSTALL_PREFIX` directly is not challenging
4. I have found 3 instance of these macros being used in existing projects (see below)

From above point 4:
1. https://github.com/CreatureSurvive/TweakSettings/blob/4162605bfebd2a925a681c81ed5f03c3152cb901/TweakSettings-App/main.m#L28 seems like a valid use, however using `THEOS_PACKAGE_INSTALL_PREFIX` directly here would be trivial, as mentioned in previous point 3
2. https://github.com/Traurige/Eneko/blob/3a260f983ac59790665b87bb9c8644d9bdaafa08/Preferences/Controllers/EnekoRootListController.m#L99C1-L100 the macro should be used on the line above which contains the string literal
3. https://github.com/AnthoPakPak/QuickPrefs/blob/ea3d221d3833e8b2e7743bb9fc163a351d692f4d/Prefs/Preferences.m#L3 looks like incorrect usage of the `defaults` subsystem

Checklist
---------
- [x] New code follows the [code rules](https://github.com/theos/headers/blob/master/README.md#code-rules)
- [x] My contribution is code written by myself from reverse-engineered headers, licensed into the Public Domain as per [LICENSE.md](LICENSE.md); or, code written by myself / taken from an existing project, released under an OSI-approved license, and I've added relevant licensing credit to [LICENSE.md](LICENSE.md)


Does this close any currently open issues?
------------------------------------------

No, although it addresses comments made on #81 after the PR was merged.


Where has this been tested?
---------------------------
**Operating System:** macOS

**Platform:** …

**Target Platform:** …

**Toolchain Version:** `Apple clang version 14.0.3`

**SDK Version:** …
