### PR TITLE
Fix XINA_SUPPORT `ROOT_PATH_NS_VAR` macro

### DIFF
--- a/rootless.h
+++ b/rootless.h
@@ -4,7 +4,7 @@
 #ifdef XINA_SUPPORT // Only define this for rootful compilations that need support for xina
 #define ROOT_PATH(cPath) !access("/var/LIY", F_OK) ? "/var/jb" cPath : cPath
 #define ROOT_PATH_NS(path) !access("/var/LIY", F_OK) ? @"/var/jb" path : path
-#define ROOT_PATH_NS_VAR !access("/var/LIY", F_OK) ? [@"/var/jb" stringByAppendingPathComponent:path] : path
+#define ROOT_PATH_NS_VAR(path) !access("/var/LIY", F_OK) ? [@"/var/jb" stringByAppendingPathComponent:path] : path
 #define ROOT_PATH_VAR(path) !access("/var/LIY", F_OK) ? ({ \
 	char outPath[PATH_MAX]; \
 	strlcpy(outPath, "/var/jb", PATH_MAX); \


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link below to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
See title

Checklist
---------
- [ ] New code follows the [code rules](https://github.com/theos/headers/blob/master/README.md#code-rules)
- [ ] I've added modulemaps for any new libraries (e.g. see [libactivator/module.modulemap](https://github.com/theos/headers/blob/f3e596d896bae8f07c43cfb00ef55bf6224b4cdc/libactivator/module.modulemap)): it should be possible to `@import MyLibrary;` in ObjC, or `import MyLibrary` in Swift.
- [ ] My contribution is code written by myself from reverse-engineered headers, licensed into the Public Domain as per [LICENSE.md](LICENSE.md); or, code written by myself / taken from an existing project, released under an OSI-approved license, and I've added relevant licensing credit to [LICENSE.md](LICENSE.md)


Does this close any currently open issues?
------------------------------------------
No

Any relevant logs, error output, etc?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
No

Where has this been tested?
---------------------------
**Operating System:** …

Linux (WSL)

**Platform:** …

**Target Platform:** …

**Toolchain Version:** …

**SDK Version:** …
