### PR TITLE
Add missing imports to `AppSupport/CP*.h`

### DIFF
--- a/AppSupport/CPBitmapStore.h
+++ b/AppSupport/CPBitmapStore.h
@@ -1,3 +1,5 @@
+#import <Foundation/NSObject.h>
+
 @interface CPBitmapStore : NSObject
 
 - (void)purge;

--- a/AppSupport/CPDistributedMessagingCenter.h
+++ b/AppSupport/CPDistributedMessagingCenter.h
@@ -1,3 +1,8 @@
+#import <Foundation/NSObject.h>
+#import <Foundation/NSString.h>
+#import <Foundation/NSDictionary.h>
+#import <Foundation/NSError.h>
+
 @interface CPDistributedMessagingCenter : NSObject
 
 + (instancetype)centerNamed:(NSString *)name;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link below to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Add missing imports to `AppSupport/CPDistributedMessagingCenter.h` and `AppSupport/CPBitmapStore.h`

Checklist
---------
- [ ] New code follows the [code rules](https://github.com/theos/headers/blob/master/README.md#code-rules)
- [ ] I've added modulemaps for any new libraries (e.g. see [libactivator/module.modulemap](https://github.com/theos/headers/blob/f3e596d896bae8f07c43cfb00ef55bf6224b4cdc/libactivator/module.modulemap)): it should be possible to `@import MyLibrary;` in ObjC, or `import MyLibrary` in Swift.
- [ ] My contribution is code written by myself from reverse-engineered headers, licensed into the Public Domain as per [LICENSE.md](LICENSE.md); or, code written by myself / taken from an existing project, released under an OSI-approved license, and I've added relevant licensing credit to [LICENSE.md](LICENSE.md)

Does this close any currently open issues?
------------------------------------------
…

Any relevant logs, error output, etc?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
**Operating System:** …

Linux (WSL)

**Platform:** …

**Target Platform:** …

**Toolchain Version:** …

**SDK Version:** …
