### PR TITLE
Import as-needed without implicitly importing UIKit

### DIFF
--- a/.github/workflows/compile-test.yml
+++ b/.github/workflows/compile-test.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           repository: theos/sdks
           ref: bb425abf3acae8eac328b828628b82df544d2774 # pinned, should be updated as appropriate
+          sparse-checkout: iPhoneOS14.5.sdk
           path: sdks
 
       - name: Checkout theos/headers
@@ -36,30 +37,25 @@ jobs:
             "rocketbootstrap/rocketbootstrap_dynamic.h" # noted to not include directly
             "libundirect/libundirect_hookoverwrite.h" # user's responsibility to include either the base or dynamic header
           )
-          
+
           HEADER_DIR="headers"
           # cut to drop the leading directory
           for HEADER in $(find "${HEADER_DIR}" -name "*.h" | cut -c"$(( ${#HEADER_DIR} + 2))"-); do
-            
+
             for UNCHECKED_DIRECTORY in "${UNCHECKED_DIRECTORIES[@]}"; do
               if [[ "${HEADER}" == "${UNCHECKED_DIRECTORY}"/* ]]; then
                 continue 2
               fi
             done
-            
+
             for UNCHECKED_FILE in "${UNCHECKED_FILES[@]}"; do
               if [[ "${HEADER}" == "${UNCHECKED_FILE}" ]]; then
                 continue 2
               fi
             done
-            
-            {
-              # Eventually we want to not require UIKit, but we're not there yet
-              echo "#import <UIKit/UIKit.h>"
-              echo "#import <${HEADER}>"
-              echo "int main() {}"
-            } | clang -I "${HEADER_DIR}" -isysroot sdks/iPhoneOS14.5.sdk \
-              -target arm64-apple-ios14.5 -arch arm64 \
-              -x "${{ matrix.language }}" ${{ matrix.cflags }} \
-              -fsyntax-only -
+
+            clang -I "${HEADER_DIR}" -isysroot sdks/iPhoneOS14.5.sdk \
+                -target arm64-apple-ios14.5 -arch arm64 \
+                -x "${{ matrix.language }}" ${{ matrix.cflags }} \
+                -stdlib=libc++ -fsyntax-only "${HEADER_DIR}/${HEADER}"
           done

--- a/.github/workflows/compile-test.yml
+++ b/.github/workflows/compile-test.yml
@@ -11,6 +11,7 @@ jobs:
         runner: ["ubuntu-latest", "macos-latest"]
         language: ["objective-c", "objective-c++"]
         cflags: ["", "-fobjc-arc"]
+        cxxflags: ["", "-stdlib=libc++"]
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout theos/sdks
@@ -57,5 +58,6 @@ jobs:
             clang -I "${HEADER_DIR}" -isysroot sdks/iPhoneOS14.5.sdk \
                 -target arm64-apple-ios14.5 -arch arm64 \
                 -x "${{ matrix.language }}" ${{ matrix.cflags }} \
-                -stdlib=libc++ -fsyntax-only "${HEADER_DIR}/${HEADER}"
+                $( [[ "${{ matrix.language }}" == *"++"* ]] && echo "${{ matrix.cxxflags }}" ) \
+                -fsyntax-only "${HEADER_DIR}/${HEADER}"
           done

--- a/.github/workflows/compile-test.yml
+++ b/.github/workflows/compile-test.yml
@@ -64,6 +64,6 @@ jobs:
               echo "int main() {}"
             } | clang -I "${HEADER_DIR}" -isysroot sdks/iPhoneOS14.5.sdk \
               -target arm64-apple-ios14.5 -arch arm64 \
-              -x "${{ matrix.language }}" "${{ matrix.cflags }}" \
-              "${ADDITIONAL_FLAGS}" -fsyntax-only -
+              -x "${{ matrix.language }}" ${{ matrix.cflags }} \
+              ${ADDITIONAL_FLAGS} -fsyntax-only -
           done

--- a/.github/workflows/compile-test.yml
+++ b/.github/workflows/compile-test.yml
@@ -11,7 +11,6 @@ jobs:
         runner: ["ubuntu-latest", "macos-latest"]
         language: ["objective-c", "objective-c++"]
         cflags: ["", "-fobjc-arc"]
-        cxxflags: ["", "-stdlib=libc++"]
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout theos/sdks
@@ -39,6 +38,11 @@ jobs:
             "libundirect/libundirect_hookoverwrite.h" # user's responsibility to include either the base or dynamic header
           )
 
+          ADDITIONAL_FLAGS=""
+          if [[ "${{ matrix.language }}" == *"++"* ]]; then
+            ADDITIONAL_FLAGS="-stdlib=libc++"
+          fi
+
           HEADER_DIR="headers"
           # cut to drop the leading directory
           for HEADER in $(find "${HEADER_DIR}" -name "*.h" | cut -c"$(( ${#HEADER_DIR} + 2))"-); do
@@ -57,7 +61,6 @@ jobs:
 
             clang -I "${HEADER_DIR}" -isysroot sdks/iPhoneOS14.5.sdk \
                 -target arm64-apple-ios14.5 -arch arm64 \
-                -x "${{ matrix.language }}" ${{ matrix.cflags }} \
-                $( [[ "${{ matrix.language }}" == *"++"* ]] && echo "${{ matrix.cxxflags }}" ) \
-                -fsyntax-only "${HEADER_DIR}/${HEADER}"
+                -x "${{ matrix.language }}" "${{ matrix.cflags }}" \
+                "${ADDITIONAL_FLAGS}" -fsyntax-only "${HEADER_DIR}/${HEADER}"
           done

--- a/.github/workflows/compile-test.yml
+++ b/.github/workflows/compile-test.yml
@@ -59,8 +59,11 @@ jobs:
               fi
             done
 
-            clang -I "${HEADER_DIR}" -isysroot sdks/iPhoneOS14.5.sdk \
-                -target arm64-apple-ios14.5 -arch arm64 \
-                -x "${{ matrix.language }}" "${{ matrix.cflags }}" \
-                "${ADDITIONAL_FLAGS}" -fsyntax-only "${HEADER_DIR}/${HEADER}"
+            {
+              echo "#import <${HEADER}>"
+              echo "int main() {}"
+            } | clang -I "${HEADER_DIR}" -isysroot sdks/iPhoneOS14.5.sdk \
+              -target arm64-apple-ios14.5 -arch arm64 \
+              -x "${{ matrix.language }}" "${{ matrix.cflags }}" \
+              "${ADDITIONAL_FLAGS}" -fsyntax-only -
           done

--- a/AVFoundation/AVCaptureStillImageOutput+Private.h
+++ b/AVFoundation/AVCaptureStillImageOutput+Private.h
@@ -1,4 +1,5 @@
 #import <AVFoundation/AVFoundation.h>
+#import <CoreGraphics/CoreGraphics.h>
 
 @interface AVCaptureStillImageOutput (Private)
 

--- a/AVFoundation/AVCaptureStillImageRequest.h
+++ b/AVFoundation/AVCaptureStillImageRequest.h
@@ -1,4 +1,5 @@
 #import <Foundation/Foundation.h>
+#import <CoreGraphics/CoreGraphics.h>
 
 @interface AVCaptureStillImageRequest : NSObject
 

--- a/AddressBookUI/ABMonogrammer.h
+++ b/AddressBookUI/ABMonogrammer.h
@@ -1,4 +1,4 @@
-#import <Foundation/Foundation.h>
+#import <UIKit/UIImage.h>
 
 typedef NS_ENUM(NSUInteger, ABMonogrammerStyle) {
 	ABMonogrammerStyleLightGray,

--- a/AlienBlue/AlienBlueAppDelegate.h
+++ b/AlienBlue/AlienBlueAppDelegate.h
@@ -1,3 +1,6 @@
+#import <UIKit/UIApplication.h>
+#import <UIKit/UIWindow.h>
+
 @interface AlienBlueAppDelegate : NSObject <UIApplicationDelegate>
 
 @property (nonatomic, retain) UIWindow *window;

--- a/AlienBlue/AppSchemeCoordinator.h
+++ b/AlienBlue/AppSchemeCoordinator.h
@@ -1,3 +1,6 @@
+#import <Foundation/NSObject.h>
+#import <Foundation/NSString.h>
+
 @interface AppSchemeCoordinator : NSObject
 
 + (void)openRedditThreadUrl:(NSString *)url;

--- a/AlienBlue/JMOutlineViewController.h
+++ b/AlienBlue/JMOutlineViewController.h
@@ -1,3 +1,5 @@
+#import <UIKit/UIViewController.h>
+
 @interface JMOutlineViewController : UIViewController
 
 @end

--- a/AlienBlue/NavigationManager.h
+++ b/AlienBlue/NavigationManager.h
@@ -1,3 +1,6 @@
+#import <Foundation/NSObject.h>
+#import <Foundation/NSString.h>
+
 @class Post;
 
 @interface NavigationManager : NSObject

--- a/AlienBlue/Post.h
+++ b/AlienBlue/Post.h
@@ -1,4 +1,5 @@
 #import "VotableElement.h"
+#import <Foundation/NSString.h>
 
 @interface Post : VotableElement
 

--- a/AlienBlue/PostsViewController.h
+++ b/AlienBlue/PostsViewController.h
@@ -1,3 +1,5 @@
+#import <UIKit/UIViewController.h>
+
 @interface PostsViewController : UIViewController
 
 - (instancetype)initWithSubreddit:(NSString *)subreddit title:(NSString *)title;

--- a/AlienBlue/VotableElement.h
+++ b/AlienBlue/VotableElement.h
@@ -1,3 +1,5 @@
+#import <Foundation/NSObject.h>
+
 @interface VotableElement : NSObject
 
 @end

--- a/Anemone/ANEMSettingsManager.h
+++ b/Anemone/ANEMSettingsManager.h
@@ -1,3 +1,6 @@
+#import <Foundation/NSObject.h>
+#import <Foundation/NSArray.h>
+
 @interface ANEMSettingsManager : NSObject
 
 + (instancetype)sharedManager;

--- a/AppList/ALApplicationList.h
+++ b/AppList/ALApplicationList.h
@@ -1,6 +1,4 @@
 #import <UIKit/UIKit.h>
-#import <Foundation/Foundation.h>
-#import <CoreGraphics/CoreGraphics.h>
 #import <libkern/OSAtomic.h>
 
 enum {

--- a/AppList/ALApplicationTableDataSource.h
+++ b/AppList/ALApplicationTableDataSource.h
@@ -1,5 +1,4 @@
 #import <UIKit/UIKit.h>
-#import <Foundation/Foundation.h>
 #import <libkern/OSAtomic.h>
 
 @class ALApplicationList;

--- a/AppList/ALValueCell.h
+++ b/AppList/ALValueCell.h
@@ -1,5 +1,4 @@
 #import <UIKit/UIKit.h>
-#import <Foundation/Foundation.h>
 
 @protocol ALValueCellDelegate;
 

--- a/AppSupport/CPBitmapStore.h
+++ b/AppSupport/CPBitmapStore.h
@@ -1,3 +1,5 @@
+#import <Foundation/NSObject.h>
+
 @interface CPBitmapStore : NSObject
 
 - (void)purge;

--- a/AppSupport/CPDistributedMessagingCenter.h
+++ b/AppSupport/CPDistributedMessagingCenter.h
@@ -1,3 +1,8 @@
+#import <Foundation/NSObject.h>
+#import <Foundation/NSString.h>
+#import <Foundation/NSDictionary.h>
+#import <Foundation/NSError.h>
+
 @interface CPDistributedMessagingCenter : NSObject
 
 + (instancetype)centerNamed:(NSString *)name;

--- a/ApplePushService/APSMessage.h
+++ b/ApplePushService/APSMessage.h
@@ -1,3 +1,8 @@
+#import <Foundation/NSObject.h>
+#import <Foundation/NSDictionary.h>
+#import <Foundation/NSString.h>
+#import <Foundation/NSObjCRuntime.h>
+
 @interface APSMessage : NSObject <NSCoding>
 
 - (id)initWithDictionary:(NSDictionary *)dictionary;

--- a/AssertionServices/BKSProcess.h
+++ b/AssertionServices/BKSProcess.h
@@ -1,3 +1,5 @@
+#import <Foundation/NSObject.h>
+
 @interface BKSProcess : NSObject
 
 @property (nonatomic, assign) BOOL nowPlayingWithAudio;

--- a/AssertionServices/BKSProcessAssertion.h
+++ b/AssertionServices/BKSProcessAssertion.h
@@ -1,3 +1,7 @@
+#import <Foundation/NSObject.h>
+#import <Foundation/NSObjCRuntime.h>
+#import <Foundation/NSString.h>
+
 #define kBKSBackgroundModeUnboundedTaskCompletion @"unboundedTaskCompletion"
 #define kBKSBackgroundModeContinuous              @"continuous"
 #define kBKSBackgroundModeFetch                   @"fetch"

--- a/BaseBoard/BSAction.h
+++ b/BaseBoard/BSAction.h
@@ -1,6 +1,7 @@
 #import "BSDescriptionProviding.h"
 #import "BSSettingDescriptionProvider.h"
 #import "BSXPCCoding.h"
+#import <Foundation/Foundation.h>
 
 @interface BSAction : NSObject <BSDescriptionProviding, BSSettingDescriptionProvider, BSXPCCoding>
 

--- a/BaseBoard/BSAuditToken.h
+++ b/BaseBoard/BSAuditToken.h
@@ -1,3 +1,6 @@
+#import <Foundation/NSObject.h>
+#import <Foundation/NSString.h>
+
 @interface BSAuditToken : NSObject <NSCopying>
 
 @property (nonatomic, copy, readonly) NSString *bundleID;

--- a/BaseBoard/BSBaseXPCClient.h
+++ b/BaseBoard/BSBaseXPCClient.h
@@ -1,3 +1,5 @@
+#import <Foundation/NSObject.h>
+
 @interface BSBaseXPCClient : NSObject
 
 @end

--- a/BaseBoard/BSPlatform.h
+++ b/BaseBoard/BSPlatform.h
@@ -1,4 +1,6 @@
-#import <Foundation/Foundation.h>
+#import <Foundation/NSObject.h>
+#import <Foundation/NSString.h>
+#import <Foundation/NSObjCRuntime.h>
 
 typedef NS_ENUM(NSUInteger, BSDeviceClass) {
 	BSDeviceClassIPhone,

--- a/BaseBoard/BSProcessHandle.h
+++ b/BaseBoard/BSProcessHandle.h
@@ -1,3 +1,7 @@
+#import <Foundation/NSObject.h>
+#import <Foundation/NSString.h>
+#import <Foundation/NSObjCRuntime.h>
+
 @class BSMachPortTaskNameRight;
 
 @interface BSProcessHandle : NSObject

--- a/BaseBoard/BSSettings.h
+++ b/BaseBoard/BSSettings.h
@@ -1,3 +1,7 @@
+#import <Foundation/NSObject.h>
+#import <Foundation/NSObjCRuntime.h>
+#import <Foundation/NSIndexSet.h>
+
 typedef NS_ENUM(NSUInteger, BSSettingType) {
 	BSSettingTypeThisIsAReminderToFillOutTheseEnumNames = 8
 };

--- a/BaseBoardUI/UIViewController+BaseBoardUI.h
+++ b/BaseBoardUI/UIViewController+BaseBoardUI.h
@@ -1,3 +1,5 @@
+#import <UIKit/UIViewController.h>
+
 @interface UIViewController (BaseBoardUI)
 
 - (BOOL)bs_addChildViewController:(UIViewController *)childController;

--- a/BiteSMS/BSQCQRLauncher.h
+++ b/BiteSMS/BSQCQRLauncher.h
@@ -1,3 +1,5 @@
+#import <Foundation/NSObject.h>
+
 @interface BSQCQRLauncher : NSObject
 
 + (void)showQuickCompose:(BOOL)isLocked;

--- a/BulletinBoard/BBAction.h
+++ b/BulletinBoard/BBAction.h
@@ -1,3 +1,7 @@
+#import <Foundation/NSObject.h>
+#import <Foundation/NSString.h>
+#import <Foundation/NSURL.h>
+
 typedef void (^BBActionCallblock)();
 
 @class BBAppearance;

--- a/BulletinBoard/BBAppearance.h
+++ b/BulletinBoard/BBAppearance.h
@@ -1,3 +1,6 @@
+#import <Foundation/NSObject.h>
+#import <Foundation/NSString.h>
+
 @interface BBAppearance : NSObject
 
 + (instancetype)appearanceWithTitle:(NSString *)title;

--- a/BulletinBoard/BBBulletin.h
+++ b/BulletinBoard/BBBulletin.h
@@ -1,4 +1,5 @@
 #import <AddressBook/AddressBook.h>
+#import <Foundation/Foundation.h>
 
 @class BBAction, BBContent, BBSectionIcon, BBSectionParameters, BBSectionSubtypeParameters;
 

--- a/BulletinBoard/BBDataProvider.h
+++ b/BulletinBoard/BBDataProvider.h
@@ -1,3 +1,6 @@
+#import <Foundation/Foundation.h>
+#import <CoreGraphics/CoreGraphics.h>
+
 @class BBActionResponse, BBBulletinRequestParameters, BBDataProviderIdentity, BBSectionIcon, BBSectionInfo, BBSectionParameters, BBThumbnailSizeConstraints;
 
 @protocol BBSectionIdentity <NSObject>

--- a/BulletinBoard/BBDataProviderIdentity.h
+++ b/BulletinBoard/BBDataProviderIdentity.h
@@ -1,3 +1,7 @@
+#import <Foundation/NSObject.h>
+#import <Foundation/NSString.h>
+#import <Foundation/NSArray.h>
+
 @class BBDataProvider, BBSectionInfo, BBSectionParameters;
 
 @interface BBDataProviderIdentity : NSObject

--- a/BulletinBoard/BBLocalDataProviderStore.h
+++ b/BulletinBoard/BBLocalDataProviderStore.h
@@ -1,3 +1,5 @@
+#import <Foundation/NSObject.h>
+
 @protocol BBDataProvider;
 
 @interface BBLocalDataProviderStore : NSObject

--- a/BulletinBoard/BBSectionIcon.h
+++ b/BulletinBoard/BBSectionIcon.h
@@ -1,3 +1,5 @@
+#import <Foundation/NSObject.h>
+
 @class BBSectionIconVariant;
 
 @interface BBSectionIcon : NSObject

--- a/BulletinBoard/BBSectionIconVariant.h
+++ b/BulletinBoard/BBSectionIconVariant.h
@@ -1,3 +1,7 @@
+#import <Foundation/NSObject.h>
+#import <Foundation/NSObjCRuntime.h>
+#import <Foundation/NSData.h>
+
 @interface BBSectionIconVariant : NSObject
 
 + (instancetype)variantWithFormat:(NSUInteger)format imageData:(NSData *)data;

--- a/BulletinBoard/BBSectionInfoSettings.h
+++ b/BulletinBoard/BBSectionInfoSettings.h
@@ -1,3 +1,6 @@
+#import <Foundation/NSObject.h>
+#import <Foundation/NSObjCRuntime.h>
+
 typedef NS_OPTIONS(NSUInteger, BBSectionInfoPushSettings) {
 	BBSectionInfoPushSettingsBadges = 1 << 0,
 	BBSectionInfoPushSettingsSounds = 1 << 1,

--- a/BulletinBoard/BBSectionParameters.h
+++ b/BulletinBoard/BBSectionParameters.h
@@ -1,3 +1,6 @@
+#import <Foundation/NSObject.h>
+#import <Foundation/NSDictionary.h>
+
 @class BBSectionSubtypeParameters;
 
 @interface BBSectionParameters : NSObject

--- a/BulletinBoard/BBSectionSubtypeParameters.h
+++ b/BulletinBoard/BBSectionSubtypeParameters.h
@@ -1,3 +1,5 @@
+#import <Foundation/NSObject.h>
+
 @interface BBSectionSubtypeParameters : NSObject
 
 @property (nonatomic) BOOL allowsAddingToLockScreenWhenUnlocked;

--- a/BulletinBoard/BBSettingsGateway.h
+++ b/BulletinBoard/BBSettingsGateway.h
@@ -1,3 +1,6 @@
+#import <Foundation/NSObject.h>
+#import <Foundation/NSString.h>
+
 @class BBSectionInfo;
 
 typedef void (^BBSettingsGatewayGetSectionInfoCompletion)(BBSectionInfo *sectionInfo);

--- a/BulletinBoard/BBThumbnailSizeConstraints.h
+++ b/BulletinBoard/BBThumbnailSizeConstraints.h
@@ -1,3 +1,6 @@
+#import <Foundation/NSObject.h>
+#import <CoreGraphics/CoreGraphics.h>
+
 @interface BBThumbnailSizeConstraints : NSObject
 
 @property (nonatomic) CGFloat fixedWidth;

--- a/BulletinBoard/BBWeeAppController.h
+++ b/BulletinBoard/BBWeeAppController.h
@@ -1,3 +1,6 @@
+#import <UIKit/UIView.h>
+#import <UIKit/UIApplication.h>
+
 @protocol BBWeeAppController
 
 - (UIView *)view;

--- a/CameraKit/UIView+CameraKitAdditions.h
+++ b/CameraKit/UIView+CameraKitAdditions.h
@@ -1,4 +1,3 @@
-#import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
 @interface UIView (CameraKit)

--- a/Celestial/AVController.h
+++ b/Celestial/AVController.h
@@ -1,3 +1,5 @@
+#import <Foundation/NSObject.h>
+
 @interface AVController : NSObject
 
 @end

--- a/Celestial/AVItem.h
+++ b/Celestial/AVItem.h
@@ -1,3 +1,5 @@
+#import <Foundation/NSObject.h>
+
 @interface AVItem : NSObject
 
 @end

--- a/Celestial/AVQueue.h
+++ b/Celestial/AVQueue.h
@@ -1,3 +1,5 @@
+#import <Foundation/NSObject.h>
+
 @interface AVQueue : NSObject
 
 @end

--- a/ChatKit/CKConversation.h
+++ b/ChatKit/CKConversation.h
@@ -1,3 +1,6 @@
+#import <Foundation/NSObject.h>
+#import <Foundation/NSString.h>
+
 @class IMChat;
 
 @interface CKConversation : NSObject

--- a/ChatKit/CKConversationList.h
+++ b/ChatKit/CKConversationList.h
@@ -1,3 +1,6 @@
+#import <Foundation/NSObject.h>
+#import <Foundation/NSArray.h>
+
 @interface CKConversationList : NSObject {
 	NSMutableArray *_trackedConversations;
 }

--- a/ChatKit/CKConversationListCell.h
+++ b/ChatKit/CKConversationListCell.h
@@ -1,3 +1,6 @@
+#import <UIKit/UITableViewCell.h>
+#import <UIKit/UILabel.h>
+
 @class CKConversation;
 
 @interface CKConversationListCell : UITableViewCell {

--- a/ChatKit/CKConversationListController.h
+++ b/ChatKit/CKConversationListController.h
@@ -1,3 +1,5 @@
+#import <UIKit/UITableViewController.h>
+
 @class CKConversationList;
 
 @interface CKConversationListController : UITableViewController

--- a/ChatKit/CKDNDList.h
+++ b/ChatKit/CKDNDList.h
@@ -1,3 +1,7 @@
+#import <Foundation/NSObject.h>
+#import <Foundation/NSDate.h>
+#import <Foundation/NSString.h>
+
 @interface CKDNDList : NSObject
 
 + (instancetype)sharedList;

--- a/ChatKit/CKDetailsCell.h
+++ b/ChatKit/CKDetailsCell.h
@@ -1,3 +1,6 @@
+#import <UIKit/UITableViewCell.h>
+#import <UIKit/UIView.h>
+
 @interface CKDetailsCell : UITableViewCell
 
 @property (nonatomic, retain) UIView *topSeperator;

--- a/ChatKit/CKDetailsChatOptionsCell.h
+++ b/ChatKit/CKDetailsChatOptionsCell.h
@@ -1,4 +1,5 @@
 #import "CKDetailsCell.h"
+#import <UIKit/UISwitch.h>
 
 @interface CKDetailsChatOptionsCell : CKDetailsCell
 

--- a/ChatKit/CKDetailsTableView.h
+++ b/ChatKit/CKDetailsTableView.h
@@ -1,3 +1,5 @@
+#import <UIKit/UITableView.h>
+
 @interface CKDetailsTableView : UITableView
 
 @end

--- a/ChatKit/CKEntity.h
+++ b/ChatKit/CKEntity.h
@@ -1,3 +1,6 @@
+#import <Foundation/NSObject.h>
+#import <Foundation/NSString.h>
+
 @class IMHandle;
 
 @interface CKEntity : NSObject

--- a/ChatKit/CKMadridService.h
+++ b/ChatKit/CKMadridService.h
@@ -1,3 +1,6 @@
+#import <Foundation/NSObject.h>
+#import <Foundation/NSString.h>
+
 @class CKMadridEntity;
 
 // 5.x

--- a/ChatKit/CKMessageCell.h
+++ b/ChatKit/CKMessageCell.h
@@ -1,3 +1,5 @@
+#import <UIKit/UITableViewCell.h>
+
 @interface CKMessageCell : UITableViewCell
 
 @end

--- a/ChatKit/CKNavigationController.h
+++ b/ChatKit/CKNavigationController.h
@@ -1,3 +1,5 @@
+#import <UIKit/UINavigationController.h>
+
 @interface CKNavigationController : UINavigationController
 
 @end

--- a/ChatKit/CKTranscriptRecipientsController.h
+++ b/ChatKit/CKTranscriptRecipientsController.h
@@ -1,3 +1,5 @@
+#import <UIKit/UITableViewController.h>
+
 @class CKConversation;
 
 @interface CKTranscriptRecipientsController : UITableViewController

--- a/ChatKit/CKTranscriptRecipientsHeaderFooterView.h
+++ b/ChatKit/CKTranscriptRecipientsHeaderFooterView.h
@@ -1,3 +1,5 @@
+#import <UIKit/UITableViewHeaderFooterView.h>
+
 @interface CKTranscriptRecipientsHeaderFooterView : UITableViewHeaderFooterView
 
 + (NSString *)identifier;

--- a/ChatKit/CKTranscriptTypingIndicatorCell.h
+++ b/ChatKit/CKTranscriptTypingIndicatorCell.h
@@ -1,3 +1,5 @@
+#import <UIKit/UIView.h>
+
 @interface CKTranscriptTypingIndicatorCell : UIView
 
 - (void)startPulseAnimation;

--- a/ChatKit/CKTypingIndicatorLayer.h
+++ b/ChatKit/CKTypingIndicatorLayer.h
@@ -1,3 +1,5 @@
+#import <QuartzCore/CALayer.h>
+
 @interface CKTypingIndicatorLayer : CALayer
 
 - (void)startGrowAnimation;

--- a/ChatKit/CKTypingView.h
+++ b/ChatKit/CKTypingView.h
@@ -1,4 +1,5 @@
 #import "CKTypingIndicatorLayer.h"
+#import <UIKit/UIView.h>
 
 @interface CKTypingView : UIView
 

--- a/ChatKit/CKViewController.h
+++ b/ChatKit/CKViewController.h
@@ -1,3 +1,5 @@
+#import <UIKit/UIViewController.h>
+
 @interface CKViewController : UIViewController
 
 @end

--- a/Contacts/CN.h
+++ b/Contacts/CN.h
@@ -1,3 +1,6 @@
+#import <Foundation/NSObject.h>
+#import <Foundation/NSArray.h>
+
 @class CNPropertyDescription;
 
 @interface CN : NSObject

--- a/Contacts/CNPredicate.h
+++ b/Contacts/CNPredicate.h
@@ -1,3 +1,5 @@
+#import <Foundation/NSPredicate.h>
+
 @interface CNPredicate : NSPredicate
 
 @end

--- a/Contacts/CNPropertyDescription.h
+++ b/Contacts/CNPropertyDescription.h
@@ -1,3 +1,6 @@
+#import <Foundation/NSObject.h>
+#import <Foundation/NSString.h>
+
 @interface CNPropertyDescription : NSObject
 
 @property (nonatomic, copy, readonly) NSString *key;

--- a/ControlCenterUIKit/CCUIContentModule-Protocol.h
+++ b/ControlCenterUIKit/CCUIContentModule-Protocol.h
@@ -1,5 +1,4 @@
 #import <UIKit/UIKit.h>
-#import <Foundation/Foundation.h>
 #import "CCUIContentModuleContentViewController-Protocol.h"
 
 @protocol CCUIContentModule <NSObject>

--- a/ControlCenterUIKit/CCUILabeledRoundButton.h
+++ b/ControlCenterUIKit/CCUILabeledRoundButton.h
@@ -1,5 +1,4 @@
 #import <UIKit/UIKit.h>
-#import <Foundation/Foundation.h>
 #import "CCUICAPackageDescription.h"
 #import "CCUIRoundButton.h"
 

--- a/ControlCenterUIKit/CCUILabeledRoundButtonViewController.h
+++ b/ControlCenterUIKit/CCUILabeledRoundButtonViewController.h
@@ -1,5 +1,4 @@
 #import <UIKit/UIKit.h>
-#import <Foundation/Foundation.h>
 #import "CCUILabeledRoundButton.h"
 #import "CCUICAPackageDescription.h"
 

--- a/ControlCenterUIKit/CCUIRoundButton.h
+++ b/ControlCenterUIKit/CCUIRoundButton.h
@@ -1,5 +1,4 @@
 #import <UIKit/UIKit.h>
-#import <Foundation/Foundation.h>
 #import "CCUICAPackageView.h"
 #import "CCUICAPackageDescription.h"
 

--- a/Foundation/NSBundle+Private.h
+++ b/Foundation/NSBundle+Private.h
@@ -1,4 +1,5 @@
-#import <Foundation/Foundation.h>
+#import <Foundation/NSBundle.h>
+#import <CoreFoundation/CoreFoundation.h>
 
 @interface NSBundle (Private)
 

--- a/Foundation/NSCache+Private.h
+++ b/Foundation/NSCache+Private.h
@@ -1,4 +1,4 @@
-#import <Foundation/Foundation.h>
+#import <Foundation/NSCache.h>
 
 @interface NSCache (Private)
 

--- a/Foundation/NSDistributedNotificationCenter.h
+++ b/Foundation/NSDistributedNotificationCenter.h
@@ -1,3 +1,5 @@
+#import <TargetConditionals.h>
+
 #if TARGET_OS_IPHONE
 #import <Foundation/Foundation.h>
 

--- a/FrontBoard/FBSSceneSettings.h
+++ b/FrontBoard/FBSSceneSettings.h
@@ -1,3 +1,5 @@
+#import <Foundation/NSObject.h>
+
 @interface FBSSceneSettings : NSObject
 
 @property (getter=isBackgrounded, nonatomic, readonly) BOOL backgrounded;

--- a/FrontBoard/FBSceneHostManager.h
+++ b/FrontBoard/FBSceneHostManager.h
@@ -1,3 +1,6 @@
+#import <Foundation/NSObject.h>
+#import <Foundation/NSString.h>
+
 @class FBScene, FBSceneHostWrapperView;
 
 @interface FBSceneHostManager : NSObject

--- a/FrontBoard/FBSceneHostWrapperView.h
+++ b/FrontBoard/FBSceneHostWrapperView.h
@@ -1,3 +1,5 @@
+#import <UIKit/UIView.h>
+
 @class FBScene;
 
 @interface FBSceneHostWrapperView : UIView

--- a/FrontBoardServices/FBSDisplay.h
+++ b/FrontBoardServices/FBSDisplay.h
@@ -1,3 +1,7 @@
+#import <Foundation/NSObject.h>
+#import <Foundation/NSObjCRuntime.h>
+#import <CoreGraphics/CoreGraphics.h>
+
 @interface FBSDisplay : NSObject
 
 @property (nonatomic, readonly) NSUInteger displayID;

--- a/FrontBoardServices/FBSOpenApplicationOptions.h
+++ b/FrontBoardServices/FBSOpenApplicationOptions.h
@@ -1,3 +1,7 @@
+#import <Foundation/NSObject.h>
+#import <Foundation/NSURL.h>
+#import <Foundation/NSDictionary.h>
+
 @interface FBSOpenApplicationOptions : NSObject <NSCopying>
 
 @property (nonatomic, copy) NSDictionary *dictionary;

--- a/FrontBoardServices/FBSSceneSettings.h
+++ b/FrontBoardServices/FBSSceneSettings.h
@@ -1,3 +1,5 @@
+#import <Foundation/NSObject.h>
+
 @interface FBSSceneSettings : NSObject <NSCopying, NSMutableCopying>
 
 @property (nonatomic, readonly, getter=isBackgrounded) BOOL backgrounded;

--- a/FrontBoardServices/FBSSceneSettingsDiff.h
+++ b/FrontBoardServices/FBSSceneSettingsDiff.h
@@ -1,3 +1,5 @@
+#import <Foundation/NSObject.h>
+
 @class FBSSceneSettings;
 
 @interface FBSSceneSettingsDiff : NSObject

--- a/GeoServices/GEOCelestialBody.h
+++ b/GeoServices/GEOCelestialBody.h
@@ -1,3 +1,5 @@
+#import <Foundation/NSObjCRuntime.h>
+
 typedef NS_ENUM(NSInteger, GEOCelestialBody) {
     GEOCelestialBodySun,
     GEOCelestialBodyMercury,

--- a/GeoServices/GEOEquatorialCelestialBodyData.h
+++ b/GeoServices/GEOEquatorialCelestialBodyData.h
@@ -1,4 +1,6 @@
 #import "GEOCelestialBody.h"
+#import <Foundation/NSObject.h>
+#import <Foundation/NSDate.h>
 
 @interface GEOEquatorialCelestialBodyData : NSObject
 

--- a/GraphicsServices/GSHeartbeat.h
+++ b/GraphicsServices/GSHeartbeat.h
@@ -1,5 +1,5 @@
 /*
- 
+
 FILE_NAME ... FILE_DESCRIPTION
 
 Copyright (c) 2009  KennyTM~ <kennytm@gmail.com>
@@ -10,7 +10,7 @@ are permitted provided that the following conditions are met:
 
 * Redistributions of source code must retain the above copyright notice, this
   list of conditions and the following disclaimer.
-* Redistributions in binary form must reproduce the above copyright notice, 
+* Redistributions in binary form must reproduce the above copyright notice,
   this list of conditions and the following disclaimer in the documentation
   and/or other materials provided with the distribution.
 * Neither the name of the KennyTM~ nor the names of its contributors may be
@@ -35,6 +35,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <CoreGraphics/CoreGraphics.h>
 #include <sys/cdefs.h>
+#include <CoreFoundation/CoreFoundation.h>
 
 __BEGIN_DECLS
 
@@ -43,10 +44,10 @@ __BEGIN_DECLS
  @brief Calls function when display updates
  @author Kenny TM~
  @date 2009 Sept 24
- 
+
  GSHeartbeat is an API that allows you to register a callback function when the display is updated. It has the same
  purpose as CADisplayLink, but have different origin.
- 
+
  */
 
 typedef struct __GSHeartbeat *GSHeartbeatRef;

--- a/GraphicsServices/GSHiccup.h
+++ b/GraphicsServices/GSHiccup.h
@@ -1,5 +1,5 @@
 /*
- 
+
 GSHiccups.h ... Hiccups.
 
 Copyright (c) 2009  KennyTM~ <kennytm@gmail.com>
@@ -10,7 +10,7 @@ are permitted provided that the following conditions are met:
 
 * Redistributions of source code must retain the above copyright notice, this
   list of conditions and the following disclaimer.
-* Redistributions in binary form must reproduce the above copyright notice, 
+* Redistributions in binary form must reproduce the above copyright notice,
   this list of conditions and the following disclaimer in the documentation
   and/or other materials provided with the distribution.
 * Neither the name of the KennyTM~ nor the names of its contributors may be
@@ -34,6 +34,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define GSHICCUPS_H
 
 #include <sys/cdefs.h>
+#include <CoreFoundation/CoreFoundation.h>
 
 __BEGIN_DECLS
 

--- a/IMCore/IMHandle.h
+++ b/IMCore/IMHandle.h
@@ -1,3 +1,7 @@
+#import <Foundation/NSObject.h>
+#import <Foundation/NSString.h>
+#import <Foundation/NSArray.h>
+
 @class IMPerson;
 
 @interface IMHandle : NSObject

--- a/IMCore/IMItemsController.h
+++ b/IMCore/IMItemsController.h
@@ -1,3 +1,5 @@
+#import <Foundation/NSObject.h>
+
 @interface IMItemsController : NSObject
 
 @end

--- a/IMCore/IMPerson.h
+++ b/IMCore/IMPerson.h
@@ -1,3 +1,6 @@
+#import <Foundation/NSObject.h>
+#import <Foundation/NSString.h>
+
 @interface IMPerson : NSObject
 
 @property (nonatomic, readonly) NSString *name;

--- a/IMCore/IMServiceImpl.h
+++ b/IMCore/IMServiceImpl.h
@@ -1,3 +1,7 @@
+#import <Foundation/NSObject.h>
+#import <Foundation/NSArray.h>
+#import <Foundation/NSString.h>
+
 @class IMPerson;
 
 @interface IMServiceImpl : NSObject

--- a/IMDaemonCore/IMDChat.h
+++ b/IMDaemonCore/IMDChat.h
@@ -1,3 +1,7 @@
+#import <Foundation/NSObject.h>
+#import <Foundation/NSDictionary.h>
+#import <Foundation/NSArray.h>
+#import <Foundation/NSString.h>
 
 @class IMDHandle;
 

--- a/IMDaemonCore/IMDChatRegistry.h
+++ b/IMDaemonCore/IMDChatRegistry.h
@@ -1,3 +1,6 @@
+#import <Foundation/NSObject.h>
+#import <Foundation/NSArray.h>
+
 @class IMDChat;
 
 @interface IMDChatRegistry : NSObject

--- a/IMDaemonCore/IMDFileTransferCenter.h
+++ b/IMDaemonCore/IMDFileTransferCenter.h
@@ -1,3 +1,6 @@
+#import <Foundation/NSObject.h>
+#import <Foundation/NSString.h>
+
 @class IMFileTransfer;
 
 @interface IMDFileTransferCenter : NSObject

--- a/IMDaemonCore/IMDHandle.h
+++ b/IMDaemonCore/IMDHandle.h
@@ -1,3 +1,6 @@
+#import <Foundation/NSObject.h>
+#import <Foundation/NSString.h>
+
 @interface IMDHandle : NSObject
 
 @property (nonatomic, retain) NSString *ID;

--- a/IMDaemonCore/IMDMessageStore.h
+++ b/IMDaemonCore/IMDMessageStore.h
@@ -1,3 +1,6 @@
+#import <Foundation/NSObject.h>
+#import <Foundation/NSString.h>
+
 @class FZMessage;
 
 @interface IMDMessageStore : NSObject

--- a/IMDaemonCore/IMDServiceSession.h
+++ b/IMDaemonCore/IMDServiceSession.h
@@ -1,3 +1,5 @@
+#import <Foundation/NSObject.h>
+
 @interface IMDServiceSession : NSObject
 
 @end

--- a/IMFoundation/IMItem.h
+++ b/IMFoundation/IMItem.h
@@ -1,3 +1,8 @@
+#import <Foundation/NSObject.h>
+#import <Foundation/NSString.h>
+#import <Foundation/NSDate.h>
+#import <Foundation/NSDictionary.h>
+
 @interface IMItem : NSObject
 
 @property (nonatomic) long long type;

--- a/IMSharedUtilities/IMFileTransfer.h
+++ b/IMSharedUtilities/IMFileTransfer.h
@@ -1,3 +1,6 @@
+#import <Foundation/NSObject.h>
+#import <Foundation/NSString.h>
+
 @interface IMFileTransfer : NSObject
 
 @property (nonatomic, retain) NSString *messageGUID;

--- a/IconSupport/ISIconSupport.h
+++ b/IconSupport/ISIconSupport.h
@@ -1,3 +1,8 @@
+#import <Foundation/NSObject.h>
+#import <Foundation/NSSet.h>
+#import <Foundation/NSString.h>
+#import <Foundation/NSDictionary.h>
+
 @interface ISIconSupport : NSObject {
     NSMutableSet *extensions;
 }

--- a/Jasmine/SchemeManager.h
+++ b/Jasmine/SchemeManager.h
@@ -1,3 +1,6 @@
+#import <Foundation/NSObject.h>
+#import <Foundation/NSURL.h>
+
 @interface SchemeManager : NSObject
 
 + (void)handleVideoOpen:(NSURL *)url;

--- a/LightMessaging/LightMessaging.h
+++ b/LightMessaging/LightMessaging.h
@@ -324,7 +324,7 @@ static inline kern_return_t LMSendCFDataReply(mach_port_t replyPort, CFDataRef d
 }
 
 #ifdef __OBJC__
-
+#import <Foundation/Foundation.h>
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 static inline id LMPropertyListForData(NSData *data)
 {

--- a/MaterialKit/MTLumaDodgePillView.h
+++ b/MaterialKit/MTLumaDodgePillView.h
@@ -1,3 +1,5 @@
+#import <UIKit/UIView.h>
+
 typedef NS_ENUM(NSUInteger, MTLumaDodgePillStyle) {
 	MTLumaDodgePillStyleNone,
 	MTLumaDodgePillStyleThin,

--- a/MediaPlayer/MPAVRoutingController.h
+++ b/MediaPlayer/MPAVRoutingController.h
@@ -1,3 +1,7 @@
+#import <Foundation/NSObject.h>
+#import <Foundation/NSObjCRuntime.h>
+#import <Foundation/NSString.h>
+
 typedef NS_ENUM(NSInteger, MPRouteDiscoveryMode) {
     MPRouteDiscoveryModeDisabled,
     MPRouteDiscoveryModePresence,

--- a/MediaPlayer/MPVideoView.h
+++ b/MediaPlayer/MPVideoView.h
@@ -1,3 +1,5 @@
+#import <UIKit/UIView.h>
+
 @interface MPVideoView : UIView
 
 @end

--- a/MediaPlayerUI/MPUMediaRemoteControlsView.h
+++ b/MediaPlayerUI/MPUMediaRemoteControlsView.h
@@ -1,3 +1,5 @@
+#import <UIKit/UIView.h>
+
 @interface MPUMediaRemoteControlsView : UIView
 
 @end

--- a/MediaPlayerUI/MPUMediaRemoteViewController.h
+++ b/MediaPlayerUI/MPUMediaRemoteViewController.h
@@ -1,3 +1,5 @@
+#import <UIKit/UIViewController.h>
+
 @interface MPUMediaRemoteViewController : UIViewController
 
 @end

--- a/MediaPlayerUI/MPUNowPlayingArtworkView.h
+++ b/MediaPlayerUI/MPUNowPlayingArtworkView.h
@@ -1,3 +1,5 @@
+#import <UIKit/UIKit.h>
+
 @interface MPUNowPlayingArtworkView : UIView
 
 @property (nonatomic, retain) UIImage *artworkImage;

--- a/MediaPlayerUI/MPUNowPlayingController.h
+++ b/MediaPlayerUI/MPUNowPlayingController.h
@@ -1,3 +1,5 @@
+#import <UIKit/UIImage.h>
+
 @class MPUNowPlayingController, MPUNowPlayingMetadata;
 
 @protocol MPUNowPlayingDelegate <NSObject>

--- a/MediaPlayerUI/MPUNowPlayingMetadata.h
+++ b/MediaPlayerUI/MPUNowPlayingMetadata.h
@@ -1,3 +1,6 @@
+#import <Foundation/NSObject.h>
+#import <Foundation/NSString.h>
+
 @interface MPUNowPlayingMetadata : NSObject
 
 @property (nonatomic, readonly) NSString *title;

--- a/MediaPlayerUI/MPUNowPlayingMetadataView.h
+++ b/MediaPlayerUI/MPUNowPlayingMetadataView.h
@@ -1,3 +1,5 @@
+#import <UIKit/UIView.h>
+
 @interface MPUNowPlayingMetadataView : UIView
 
 @property (nonatomic, copy) NSAttributedString *attributedText;

--- a/MediaPlayerUI/MPUTransportControlsView.h
+++ b/MediaPlayerUI/MPUTransportControlsView.h
@@ -1,3 +1,5 @@
+#import <UIKit/UIView.h>
+
 @interface MPUTransportControlsView : UIView
 
 @property (assign) NSInteger minimumNumberOfTransportButtonsForLayout;

--- a/MobilePhone/RecentCall.h
+++ b/MobilePhone/RecentCall.h
@@ -1,3 +1,5 @@
+#import <Foundation/NSObject.h>
+
 @interface RecentCall : NSObject
 
 - (int)type;

--- a/MobilePhone/RecentsTableViewCell.h
+++ b/MobilePhone/RecentsTableViewCell.h
@@ -1,3 +1,5 @@
+#import <UIKit/UITableViewCell.h>
+
 @class RecentCall;
 
 @interface RecentsTableViewCell : UITableViewCell

--- a/MobilePhone/RecentsTableViewCellContentView.h
+++ b/MobilePhone/RecentsTableViewCellContentView.h
@@ -1,3 +1,5 @@
+#import <UIKit/UIView.h>
+
 @interface RecentsTableViewCellContentView : UIView
 
 @end

--- a/MobileSMS/mSMSMessageTranscriptController.h
+++ b/MobileSMS/mSMSMessageTranscriptController.h
@@ -1,3 +1,5 @@
+#import <Foundation/NSObject.h>
+
 @interface mSMSMessageTranscriptController : NSObject
 
 @end

--- a/MobileTimer/WorldClockView.h
+++ b/MobileTimer/WorldClockView.h
@@ -1,6 +1,7 @@
 // app
 
 #import <UIKit/UIView.h>
+#import <UIKit/UILabel.h>
 
 @class WorldClockCity;
 

--- a/Pandora/NowPlayingDrawerCell.h
+++ b/Pandora/NowPlayingDrawerCell.h
@@ -1,3 +1,6 @@
+#import <UIKit/UITableViewCell.h>
+#import <UIKit/UIImageView.h>
+
 @interface NowPlayingDrawerCell : UITableViewCell
 
 @property (nonatomic, retain) UIImageView *leftImageView;

--- a/Pandora/PMRadio.h
+++ b/Pandora/PMRadio.h
@@ -1,3 +1,5 @@
+#import <Foundation/NSObject.h>
+
 @class TrackDescriptor;
 
 @interface PMRadio : NSObject

--- a/Pandora/TrackDescriptor.h
+++ b/Pandora/TrackDescriptor.h
@@ -1,3 +1,6 @@
+#import <Foundation/NSObject.h>
+#import <Foundation/NSString.h>
+
 @interface TrackDescriptor : NSObject
 
 @property (nonatomic, retain) NSString *songName;

--- a/PassKitUI/PKGlyphViewDelegate.h
+++ b/PassKitUI/PKGlyphViewDelegate.h
@@ -1,3 +1,6 @@
+#import <Foundation/NSObject.h>
+#import <Foundation/NSObjCRuntime.h>
+
 @class PKGlyphView;
 
 @protocol PKGlyphViewDelegate <NSObject>

--- a/PassKitUIFoundation/PKGlyphView.h
+++ b/PassKitUIFoundation/PKGlyphView.h
@@ -1,4 +1,5 @@
 #import <PassKitUI/PKGlyphViewDelegate.h>
+#import <UIKit/UIView.h>
 
 @interface PKGlyphView : UIView
 

--- a/PersistentConnection/PCPersistentTimer.h
+++ b/PersistentConnection/PCPersistentTimer.h
@@ -1,3 +1,8 @@
+#import <Foundation/NSObject.h>
+#import <Foundation/NSDate.h>
+#import <Foundation/NSString.h>
+#import <Foundation/NSRunLoop.h>
+
 @interface PCPersistentTimer : NSObject
 
 - (instancetype)initWithFireDate:(NSDate *)fireDate serviceIdentifier:(NSString *)serviceIdentifier target:(id)target selector:(SEL)selector userInfo:(id)userInfo;

--- a/PhotoLibrary/PLCropOverlay.h
+++ b/PhotoLibrary/PLCropOverlay.h
@@ -1,5 +1,4 @@
 #import <UIKit/UIKit.h>
-#import <Foundation/Foundation.h>
 
 @interface PLCropOverlay : UIView
 

--- a/PhotoLibrary/PLWallpaperImageViewController.h
+++ b/PhotoLibrary/PLWallpaperImageViewController.h
@@ -1,4 +1,3 @@
-#import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
 typedef NS_ENUM(NSUInteger, PLWallpaperMode) {

--- a/PhotoLibrary/UIView+PhotoLibraryAdditions.h
+++ b/PhotoLibrary/UIView+PhotoLibraryAdditions.h
@@ -1,5 +1,4 @@
 #import <UIKit/UIKit.h>
-#import <Foundation/Foundation.h>
 
 @interface UIView (PhotoLibraryAdditions)
 

--- a/PhotoLibraryServices/PLManagedAlbum.h
+++ b/PhotoLibraryServices/PLManagedAlbum.h
@@ -1,3 +1,6 @@
+#import <Foundation/NSObject.h>
+#import <Foundation/NSOrderedSet.h>
+
 @interface PLManagedAlbum : NSObject
 
 @property (nonatomic, retain) NSOrderedSet *assets;

--- a/PhotoLibraryServices/PLManagedAsset.h
+++ b/PhotoLibraryServices/PLManagedAsset.h
@@ -1,3 +1,5 @@
+#import <UIKit/UIImage.h>
+
 @interface PLManagedAsset : NSObject
 
 - (UIImage *)newFullSizeImage;

--- a/PhotoLibraryServices/PLPhotoLibrary.h
+++ b/PhotoLibraryServices/PLPhotoLibrary.h
@@ -1,3 +1,5 @@
+#import <Foundation/NSObject.h>
+
 @class PLManagedAlbum;
 
 @interface PLPhotoLibrary : NSObject

--- a/PhotosUI/UIImage+PhotosUIAdditions.h
+++ b/PhotosUI/UIImage+PhotosUIAdditions.h
@@ -1,5 +1,4 @@
 #import <UIKit/UIKit.h>
-#import <Foundation/Foundation.h>
 
 @interface UIImage (PhotosUI)
 

--- a/Preferences/PSRootController.h
+++ b/Preferences/PSRootController.h
@@ -1,5 +1,4 @@
 #import <UIKit/UIKit.h>
-#import <Foundation/Foundation.h>
 
 @class PSListController;
 

--- a/Preferences/PSTableCell.h
+++ b/Preferences/PSTableCell.h
@@ -1,5 +1,4 @@
 #import <UIKit/UIKit.h>
-#import <Foundation/Foundation.h>
 
 @class PSSpecifier;
 

--- a/Preferences/PreferencesAppController.h
+++ b/Preferences/PreferencesAppController.h
@@ -1,3 +1,5 @@
+#import <UIKit/UIApplication.h>
+
 @class PSUIPrefsRootController;
 
 @interface PreferencesAppController : UIApplication/*this is from Preferences.app, not framework*/

--- a/QuartzCore/CABackdropLayer.h
+++ b/QuartzCore/CABackdropLayer.h
@@ -1,4 +1,5 @@
-#import <QuartzCore/CALayer.h>
+#import <Foundation/Foundation.h>
+#import <QuartzCore/QuartzCore.h>
 
 @interface CABackdropLayer : CALayer
 

--- a/SparkAppItem.h
+++ b/SparkAppItem.h
@@ -1,3 +1,5 @@
+#import <UIKit/UIImage.h>
+
 @interface SparkAppItem : NSObject
 @property (nonatomic, retain) NSString* bundleIdentifier;
 @property (nonatomic, retain) NSString* displayName;

--- a/SparkAppList.h
+++ b/SparkAppList.h
@@ -1,3 +1,7 @@
+#import <Foundation/NSObject.h>
+#import <Foundation/NSArray.h>
+#import <Foundation/NSString.h>
+
 @interface SparkAppList : NSObject
 {
 	id handler;

--- a/SparkAppListTableViewController.h
+++ b/SparkAppListTableViewController.h
@@ -1,3 +1,5 @@
+#import <UIKit/UITableViewController.h>
+
 @interface SparkAppListTableViewController : UITableViewController
 @property (nonatomic, retain) NSArray* appList;
 

--- a/SplashBoard/XBApplicationSnapshot.h
+++ b/SplashBoard/XBApplicationSnapshot.h
@@ -1,4 +1,5 @@
 #import <Foundation/Foundation.h>
+#import <CoreGraphics/CoreGraphics.h>
 
 @interface XBApplicationSnapshot : NSObject
 

--- a/SpringBoard/BBBulletin+SpringBoardAdditions.h
+++ b/SpringBoard/BBBulletin+SpringBoardAdditions.h
@@ -1,5 +1,6 @@
 #import <BulletinBoard/BBBulletin.h>
 #import <MobileIcons/MobileIcons.h>
+#import <UIKit/UIImage.h>
 
 @interface BBBulletin (SpringBoardAdditions)
 

--- a/SpringBoard/SBAppSliderController.h
+++ b/SpringBoard/SBAppSliderController.h
@@ -1,4 +1,5 @@
 #import "SBAppSliderScrollingViewDelegate.h"
+#import <UIKit/UIViewController.h>
 
 @class SBAppSliderScrollingViewController;
 

--- a/SpringBoard/SBAppSliderScrollingViewDelegate.h
+++ b/SpringBoard/SBAppSliderScrollingViewDelegate.h
@@ -1,3 +1,5 @@
+#import <Foundation/NSObjCRuntime.h>
+
 @class SBAppSliderScrollingViewController;
 
 @protocol SBAppSliderScrollingViewDelegate

--- a/SpringBoard/SBAppSwitcherController.h
+++ b/SpringBoard/SBAppSwitcherController.h
@@ -1,4 +1,5 @@
 #import "SBAppSwitcherScrollingViewDelegate.h"
+#import <UIKit/UIViewController.h>
 
 @class SBAppSwitcherPageViewController;
 

--- a/SpringBoard/SBAppSwitcherModel.h
+++ b/SpringBoard/SBAppSwitcherModel.h
@@ -1,3 +1,5 @@
+#import <Foundation/Foundation.h>
+
 @class SBDisplayItem, SBDisplayLayout;
 
 @interface SBAppSwitcherModel : NSObject

--- a/SpringBoard/SBAppSwitcherPageViewController.h
+++ b/SpringBoard/SBAppSwitcherPageViewController.h
@@ -1,3 +1,5 @@
+#import <UIKit/UIViewController.h>
+
 @class SBDisplayItem;
 
 @interface SBAppSwitcherPageViewController : UIViewController

--- a/SpringBoard/SBAppSwitcherPeopleButtonAndLabelView.h
+++ b/SpringBoard/SBAppSwitcherPeopleButtonAndLabelView.h
@@ -1,3 +1,6 @@
+#import <UIKit/UIView.h>
+#import <UIKit/UIImage.h>
+
 @interface SBAppSwitcherPeopleButtonAndLabelView : UIView
 
 - (instancetype)initWithFrame:(CGRect)frame forMonogramSize:(CGFloat)monogramSize compact:(BOOL)compact;

--- a/SpringBoard/SBAppSwitcherPeopleDataSource.h
+++ b/SpringBoard/SBAppSwitcherPeopleDataSource.h
@@ -1,3 +1,6 @@
+#import <Foundation/Foundation.h>
+#import <CoreGraphics/CoreGraphics.h>
+
 @protocol SBAppSwitcherPeopleDataSourceConsumer;
 
 @protocol SBAppSwitcherPeopleDataSource <NSObject>

--- a/SpringBoard/SBAppSwitcherPeopleScrollView.h
+++ b/SpringBoard/SBAppSwitcherPeopleScrollView.h
@@ -1,3 +1,5 @@
+#import <UIKit/UIScrollView.h>
+
 @interface SBAppSwitcherPeopleScrollView : UIScrollView
 
 - (void)updateDataVisibleOnly:(BOOL)visibleOnly animated:(BOOL)animated;

--- a/SpringBoard/SBAppSwitcherPeopleScrollViewDelegate.h
+++ b/SpringBoard/SBAppSwitcherPeopleScrollViewDelegate.h
@@ -1,3 +1,6 @@
+#import <UIKit/UIView.h>
+#import <UIKit/UIScrollView.h>
+
 @class SBAppSwitcherPeopleScrollView, SBScrollViewItemWrapper;
 
 @protocol SBAppSwitcherPeopleScrollViewDelegate <UIScrollViewDelegate>

--- a/SpringBoard/SBAppSwitcherPeopleViewController.h
+++ b/SpringBoard/SBAppSwitcherPeopleViewController.h
@@ -1,3 +1,5 @@
+#import <UIKit/UIViewController.h>
+
 @class ABMonogrammer;
 @protocol SBAppSwitcherPeopleDataSource;
 

--- a/SpringBoard/SBAppSwitcherScrollingViewDelegate.h
+++ b/SpringBoard/SBAppSwitcherScrollingViewDelegate.h
@@ -1,3 +1,5 @@
+#include <stdbool.h>
+
 @class SBAppSwitcherPageViewController, SBDisplayItem, SBDisplayLayout;
 
 @protocol SBAppSwitcherScrollingViewDelegate

--- a/SpringBoard/SBAppSwitcherSnapshotView.h
+++ b/SpringBoard/SBAppSwitcherSnapshotView.h
@@ -1,3 +1,6 @@
+#import <UIKit/UIView.h>
+#import <UIKit/UIImage.h>
+
 @class SBDisplayItem, _SBAppSwitcherSnapshotContext, XBApplicationSnapshot;
 
 @interface SBAppSwitcherSnapshotView : UIView

--- a/SpringBoard/SBAppView.h
+++ b/SpringBoard/SBAppView.h
@@ -1,4 +1,5 @@
 #import <UIKit/UIView.h>
+#import <UIKit/UIApplication.h>
 
 @class SBApplication, FBSDisplay;
 

--- a/SpringBoard/SBAppViewControllerDelegate.h
+++ b/SpringBoard/SBAppViewControllerDelegate.h
@@ -1,3 +1,6 @@
+#import <Foundation/NSObjCRuntime.h>
+#import <Foundation/NSObject.h>
+
 @class SBApplication, SBAppViewController;
 
 @protocol SBAppViewControllerDelegate <NSObject>

--- a/SpringBoard/SBAppWindow.h
+++ b/SpringBoard/SBAppWindow.h
@@ -1,3 +1,5 @@
+#import <Foundation/NSObject.h>
+
 @interface SBAppWindow : NSObject
 
 @end

--- a/SpringBoard/SBApplicationController.h
+++ b/SpringBoard/SBApplicationController.h
@@ -1,3 +1,5 @@
+#import <Foundation/Foundation.h>
+
 @class SBApplication, FBUIApplicationService;
 
 @interface SBApplicationController : NSObject

--- a/SpringBoard/SBApplicationHosting.h
+++ b/SpringBoard/SBApplicationHosting.h
@@ -1,4 +1,3 @@
-#import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
 @class SBApplication;

--- a/SpringBoard/SBApplicationIcon.h
+++ b/SpringBoard/SBApplicationIcon.h
@@ -1,5 +1,6 @@
 #import "SBLeafIcon.h"
 #import "SBIconImageInfo.h"
+#import <UIKit/UIImage.h>
 
 @class SBApplication;
 

--- a/SpringBoard/SBAssistantController.h
+++ b/SpringBoard/SBAssistantController.h
@@ -1,3 +1,6 @@
+#import <Foundation/NSObject.h>
+#import <Foundation/NSObjCRuntime.h>
+
 @interface SBAssistantController : NSObject
 
 + (instancetype)sharedInstance;

--- a/SpringBoard/SBAwayController.h
+++ b/SpringBoard/SBAwayController.h
@@ -1,3 +1,5 @@
+#import <Foundation/NSObject.h>
+
 @class SBAwayView;
 
 @interface SBAwayController : NSObject

--- a/SpringBoard/SBAwayListItem.h
+++ b/SpringBoard/SBAwayListItem.h
@@ -1,3 +1,5 @@
+#import <Foundation/NSObject.h>
+
 @interface SBAwayListItem : NSObject
 
 @end

--- a/SpringBoard/SBAwayNotificationListCell.h
+++ b/SpringBoard/SBAwayNotificationListCell.h
@@ -1,3 +1,5 @@
+#import <UIKit/UITableViewCell.h>
+
 @class BBBulletin;
 
 @interface SBAwayNotificationListCell : UITableViewCell

--- a/SpringBoard/SBAwayView.h
+++ b/SpringBoard/SBAwayView.h
@@ -1,3 +1,5 @@
+#import <UIKit/UIView.h>
+
 @interface SBAwayView : UIView
 
 @end

--- a/SpringBoard/SBBBItemInfo.h
+++ b/SpringBoard/SBBBItemInfo.h
@@ -1,3 +1,5 @@
+#import <Foundation/NSObject.h>
+
 @interface SBBBItemInfo : NSObject
 
 @end

--- a/SpringBoard/SBBBSectionInfo.h
+++ b/SpringBoard/SBBBSectionInfo.h
@@ -1,4 +1,5 @@
 #import "SBBBItemInfo.h"
+#import <Foundation/NSString.h>
 
 @interface SBBBSectionInfo : SBBBItemInfo
 

--- a/SpringBoard/SBBacklightController.h
+++ b/SpringBoard/SBBacklightController.h
@@ -1,3 +1,6 @@
+#import <Foundation/NSObject.h>
+#import <Foundation/NSString.h>
+
 @interface SBBacklightController : NSObject
 
 + (SBBacklightController *)sharedInstance;

--- a/SpringBoard/SBBannerContextView.h
+++ b/SpringBoard/SBBannerContextView.h
@@ -1,3 +1,5 @@
+#import <UIKit/UIView.h>
+
 @interface SBBannerContextView : UIView
 
 @end

--- a/SpringBoard/SBBannerController.h
+++ b/SpringBoard/SBBannerController.h
@@ -1,3 +1,6 @@
+#import <Foundation/NSObject.h>
+#import <Foundation/NSObjCRuntime.h>
+
 @interface SBBannerController : NSObject
 
 + (instancetype)sharedInstance;

--- a/SpringBoard/SBBannerView.h
+++ b/SpringBoard/SBBannerView.h
@@ -1,3 +1,5 @@
+#import <UIKit/UIView.h>
+
 NS_CLASS_DEPRECATED_IOS(5_0, 6_0) @interface SBBannerView : UIView
 
 @end

--- a/SpringBoard/SBBookmarkIcon.h
+++ b/SpringBoard/SBBookmarkIcon.h
@@ -1,3 +1,5 @@
+#import <Foundation/NSObject.h>
+
 @interface SBBookmarkIcon : NSObject
 
 @end

--- a/SpringBoard/SBBrightnessController.h
+++ b/SpringBoard/SBBrightnessController.h
@@ -1,3 +1,5 @@
+#import <Foundation/NSObject.h>
+
 @interface SBBrightnessController : NSObject
 
 + (SBBrightnessController *)sharedBrightnessController;

--- a/SpringBoard/SBBulletinBannerController.h
+++ b/SpringBoard/SBBulletinBannerController.h
@@ -1,3 +1,6 @@
+#import <Foundation/NSObject.h>
+#import <Foundation/NSObjCRuntime.h>
+
 @class BBObserver, BBBulletinRequest, BBBulletin;
 
 @interface SBBulletinBannerController : NSObject

--- a/SpringBoard/SBBulletinBannerItem.h
+++ b/SpringBoard/SBBulletinBannerItem.h
@@ -1,3 +1,5 @@
+#import <Foundation/NSObject.h>
+
 @class BBBulletin;
 
 @interface SBBulletinBannerItem : NSObject

--- a/SpringBoard/SBBulletinListCell.h
+++ b/SpringBoard/SBBulletinListCell.h
@@ -1,3 +1,6 @@
+#import <UIKit/UITableViewCell.h>
+#import <UIKit/UIView.h>
+
 typedef enum {
 	SBBulletinListCellAccessoryStyleNone = 0,
 	SBBulletinListCellAccessoryStyleDot = 1

--- a/SpringBoard/SBBulletinListSection.h
+++ b/SpringBoard/SBBulletinListSection.h
@@ -1,3 +1,7 @@
+#import <Foundation/NSObject.h>
+#import <Foundation/NSString.h>
+#import <Foundation/NSArray.h>
+
 @class BBBulletin;
 
 @interface SBBulletinListSection : NSObject

--- a/SpringBoard/SBBulletinObserverViewController.h
+++ b/SpringBoard/SBBulletinObserverViewController.h
@@ -1,3 +1,5 @@
+#import <UIKit/UIViewController.h>
+
 @class BBObserver, BBBulletin;
 
 @interface SBBulletinObserverViewController : UIViewController

--- a/SpringBoard/SBBulletinViewController.h
+++ b/SpringBoard/SBBulletinViewController.h
@@ -1,3 +1,5 @@
+#import <UIKit/UITableViewController.h>
+
 @class SBNotificationsBulletinInfo, SBNotificationCenterSectionInfo;
 
 @interface SBBulletinViewController : UITableViewController

--- a/SpringBoard/SBBulletinWindowController.h
+++ b/SpringBoard/SBBulletinWindowController.h
@@ -1,3 +1,6 @@
+#import <Foundation/NSObject.h>
+#import <Foundation/NSString.h>
+
 @interface SBBulletinWindowController : NSObject
 
 + (instancetype)sharedInstance;

--- a/SpringBoard/SBButtonBar.h
+++ b/SpringBoard/SBButtonBar.h
@@ -1,3 +1,5 @@
+#import <Foundation/NSObject.h>
+
 @interface SBButtonBar : NSObject
 
 @end

--- a/SpringBoard/SBCalendarIconContentsView.h
+++ b/SpringBoard/SBCalendarIconContentsView.h
@@ -1,3 +1,5 @@
+#import <Foundation/NSObject.h>
+
 @interface SBCalendarIconContentsView : NSObject
 
 @end

--- a/SpringBoard/SBChevronView.h
+++ b/SpringBoard/SBChevronView.h
@@ -1,3 +1,5 @@
+#import <UIKit/UIView.h>
+
 @interface SBChevronView : UIView
 
 @end

--- a/SpringBoard/SBControlCenterController.h
+++ b/SpringBoard/SBControlCenterController.h
@@ -1,3 +1,5 @@
+#import <Foundation/NSObject.h>
+
 @interface SBControlCenterController : NSObject
 
 + (instancetype)sharedInstance;

--- a/SpringBoard/SBControlColorSettings.h
+++ b/SpringBoard/SBControlColorSettings.h
@@ -1,3 +1,5 @@
+#import <UIKit/UIColor.h>
+
 @interface SBControlColorSettings : NSObject
 
 + (instancetype)settingsWithTintColor:(UIColor *)tintColor selectedTintColor:(UIColor *)selectedTextColor textColor:(UIColor *)textColor selectedTextColor:(UIColor *)selectedTextColor;

--- a/SpringBoard/SBDeckSwitcherViewController.h
+++ b/SpringBoard/SBDeckSwitcherViewController.h
@@ -1,3 +1,5 @@
+#import <UIKit/UIViewController.h>
+
 @interface SBDeckSwitcherViewController : UIViewController
 
 @end

--- a/SpringBoard/SBDefaultBannerTextView.h
+++ b/SpringBoard/SBDefaultBannerTextView.h
@@ -1,3 +1,5 @@
+#import <UIKit/UIView.h>
+
 @interface SBDefaultBannerTextView : UIView
 
 - (BOOL)textWillWrapForWidth:(CGFloat)width;

--- a/SpringBoard/SBDefaultBannerView.h
+++ b/SpringBoard/SBDefaultBannerView.h
@@ -1,3 +1,5 @@
+#import <UIKit/UIView.h>
+
 @interface SBDefaultBannerView : UIView
 
 @end

--- a/SpringBoard/SBDisplayItem.h
+++ b/SpringBoard/SBDisplayItem.h
@@ -1,3 +1,6 @@
+#import <Foundation/NSObject.h>
+#import <Foundation/NSString.h>
+
 @interface SBDisplayItem : NSObject
 
 @property (nonatomic, retain, readonly) NSString *type;

--- a/SpringBoard/SBDisplayLayout.h
+++ b/SpringBoard/SBDisplayLayout.h
@@ -1,3 +1,6 @@
+#import <Foundation/NSObject.h>
+#import <Foundation/NSArray.h>
+
 @interface SBDisplayLayout : NSObject
 
 @property (nonatomic, retain, readonly) NSArray *displayItems;

--- a/SpringBoard/SBDockView.h
+++ b/SpringBoard/SBDockView.h
@@ -1,3 +1,5 @@
+#import <UIKit/UIView.h>
+
 @interface SBDockView : UIView
 
 - (void)setBackgroundAlpha:(CGFloat)backgroundAlpha;

--- a/SpringBoard/SBExternalCarrierDefaults.h
+++ b/SpringBoard/SBExternalCarrierDefaults.h
@@ -1,3 +1,6 @@
+#import <Foundation/NSObject.h>
+#import <Foundation/NSString.h>
+
 @interface SBExternalCarrierDefaults : NSObject
 
 @property (readonly, nonatomic) NSString *carrierName;

--- a/SpringBoard/SBExternalDefaults.h
+++ b/SpringBoard/SBExternalDefaults.h
@@ -1,3 +1,5 @@
+#import <Foundation/NSObject.h>
+
 @class SBExternalCarrierDefaults;
 
 @interface SBExternalDefaults : NSObject

--- a/SpringBoard/SBFolderSlidingView.h
+++ b/SpringBoard/SBFolderSlidingView.h
@@ -1,4 +1,4 @@
-#import <UIKit/UIKit.h>
+#import <UIKit/UIView.h>
 
 @interface SBFolderSlidingView : UIView
 

--- a/SpringBoard/SBFolderView.h
+++ b/SpringBoard/SBFolderView.h
@@ -1,4 +1,4 @@
-#import <UIKit/UIKit.h>
+#import <UIKit/UIView.h>
 
 @interface SBFolderView : UIView
 

--- a/SpringBoard/SBHUDView.h
+++ b/SpringBoard/SBHUDView.h
@@ -1,3 +1,6 @@
+#import <UIKit/UIView.h>
+#import <UIKit/UIImage.h>
+
 @interface SBHUDView : UIView
 
 + (CGFloat)progressIndicatorStep;

--- a/SpringBoard/SBHomeGrabberView.h
+++ b/SpringBoard/SBHomeGrabberView.h
@@ -1,3 +1,5 @@
+#import <UIKit/UIView.h>
+
 @interface SBHomeGrabberView : UIView
 
 - (CGRect)_calculatePillFrame;

--- a/SpringBoard/SBIconContentView.h
+++ b/SpringBoard/SBIconContentView.h
@@ -1,3 +1,5 @@
+#import <UIKit/UIView.h>
+
 @interface SBIconContentView : UIView
 
 @end

--- a/SpringBoard/SBIconLabel.h
+++ b/SpringBoard/SBIconLabel.h
@@ -1,3 +1,5 @@
+#import <UIKit/UIControl.h>
+
 @interface SBIconLabel : UIControl
 
 @property BOOL inDock;

--- a/SpringBoard/SBIconList.h
+++ b/SpringBoard/SBIconList.h
@@ -1,4 +1,4 @@
-#import <Foundation/Foundation.h>
+#import <UIKit/UIView.h>
 
 API_DEPRECATED_WITH_REPLACEMENT("SBIconListView", ios(2.0, 4.0)) @interface SBIconList : UIView
 

--- a/SpringBoard/SBIconListView.h
+++ b/SpringBoard/SBIconListView.h
@@ -1,6 +1,6 @@
 #import <SpringBoardHome/SBHIconGridSize.h>
 #import <SpringBoardHome/SBHIconGridSizeClass.h>
-#import <CoreGraphics/CoreGraphics.h>
+#import <UIKit/UIView.h>
 
 API_AVAILABLE(ios(4.0))
 @interface SBIconListView : UIView

--- a/SpringBoard/SBIconView.h
+++ b/SpringBoard/SBIconView.h
@@ -1,5 +1,4 @@
-#import <UIKit/UIKit.h>
-#import <Foundation/Foundation.h>
+#import <UIKit/UIView.h>
 
 @class SBIcon;
 

--- a/SpringBoard/SBImageCache.h
+++ b/SpringBoard/SBImageCache.h
@@ -1,3 +1,5 @@
+#import <Foundation/NSObject.h>
+
 @interface SBImageCache : NSObject
 
 @end

--- a/SpringBoard/SBLockScreenNotificationListController.h
+++ b/SpringBoard/SBLockScreenNotificationListController.h
@@ -1,3 +1,5 @@
+#import <UIKit/UIViewController.h>
+
 @class BBObserver, BBBulletin;
 
 @interface SBLockScreenNotificationListController : UIViewController

--- a/SpringBoard/SBLockScreenNotificationListView.h
+++ b/SpringBoard/SBLockScreenNotificationListView.h
@@ -1,3 +1,5 @@
+#import <UIKit/UIView.h>
+
 @protocol SBLockScreenNotificationModel;
 
 @interface SBLockScreenNotificationListView : UIView

--- a/SpringBoard/SBLockScreenNotificationModel.h
+++ b/SpringBoard/SBLockScreenNotificationModel.h
@@ -1,3 +1,5 @@
+#import <Foundation/NSIndexPath.h>
+
 @class SBAwayBulletinListItem;
 
 @protocol SBLockScreenNotificationModel

--- a/SpringBoard/SBLockScreenView.h
+++ b/SpringBoard/SBLockScreenView.h
@@ -1,3 +1,5 @@
+#import <UIKit/UIView.h>
+
 @class SBChevronView;
 
 @interface SBLockScreenView : UIView

--- a/SpringBoard/SBLockScreenViewController.h
+++ b/SpringBoard/SBLockScreenViewController.h
@@ -1,3 +1,5 @@
+#import <UIKit/UIViewController.h>
+
 @interface SBLockScreenViewController : UIViewController
 
 @end

--- a/SpringBoard/SBMainWorkspace.h
+++ b/SpringBoard/SBMainWorkspace.h
@@ -1,4 +1,5 @@
 #import "SBWorkspace.h"
+#import <CoreGraphics/CoreGraphics.h>
 
 @class FBSceneManager;
 

--- a/SpringBoard/SBNotificationCell.h
+++ b/SpringBoard/SBNotificationCell.h
@@ -1,3 +1,6 @@
+#import <UIKit/UIView.h>
+#import <UIKit/UITableViewCell.h>
+
 @interface SBNotificationCell : UITableViewCell
 
 @property (nonatomic, retain) UIView *realContentView;

--- a/SpringBoard/SBNotificationCenterSectionInfo.h
+++ b/SpringBoard/SBNotificationCenterSectionInfo.h
@@ -1,3 +1,5 @@
+#import <Foundation/NSObject.h>
+
 @class SBBulletinListSection;
 
 @interface SBNotificationCenterSectionInfo : NSObject

--- a/SpringBoard/SBNotificationCenterViewController.h
+++ b/SpringBoard/SBNotificationCenterViewController.h
@@ -1,3 +1,5 @@
+#import <UIKit/UIViewController.h>
+
 @class SBBulletinObserverViewController;
 
 @interface SBNotificationCenterViewController : UIViewController

--- a/SpringBoard/SBNotificationCenterWidgetController.h
+++ b/SpringBoard/SBNotificationCenterWidgetController.h
@@ -1,3 +1,6 @@
+#import <Foundation/NSObject.h>
+#import <Foundation/NSString.h>
+
 @interface SBNotificationCenterWidgetController : NSObject
 
 + (NSString *)containingBundleIdentifierForWidgetWithBundleIdentifer:(NSString *)identifier;

--- a/SpringBoard/SBNotificationControlColorSettings.h
+++ b/SpringBoard/SBNotificationControlColorSettings.h
@@ -1,3 +1,5 @@
+#import <Foundation/NSObject.h>
+
 @class SBControlColorSettings;
 
 @interface SBNotificationControlColorSettings : NSObject

--- a/SpringBoard/SBNotificationsModeViewController.h
+++ b/SpringBoard/SBNotificationsModeViewController.h
@@ -1,3 +1,5 @@
+#import <UIKit/UIViewController.h>
+
 @interface SBNotificationsModeViewController : UIViewController
 
 @end

--- a/SpringBoard/SBNotificationsSectionHeaderView.h
+++ b/SpringBoard/SBNotificationsSectionHeaderView.h
@@ -1,3 +1,5 @@
+#import <UIKit/UITableViewHeaderFooterView.h>
+
 @interface SBNotificationsSectionHeaderView : UITableViewHeaderFooterView
 
 @end

--- a/SpringBoard/SBOrientationLockManager.h
+++ b/SpringBoard/SBOrientationLockManager.h
@@ -1,3 +1,6 @@
+#import <Foundation/NSObjCRuntime.h>
+#import <Foundation/NSObject.h>
+
 @interface SBOrientationLockManager : NSObject
 
 + (instancetype)sharedInstance;

--- a/SpringBoard/SBPagedScrollView.h
+++ b/SpringBoard/SBPagedScrollView.h
@@ -1,4 +1,3 @@
-#import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
 @interface SBPagedScrollView : UIScrollView

--- a/SpringBoard/SBPreciseClockTimer.h
+++ b/SpringBoard/SBPreciseClockTimer.h
@@ -1,3 +1,5 @@
+#import <Foundation/Foundation.h>
+
 @interface SBPreciseClockTimer : NSObject
 
 + (NSDate *)now;

--- a/SpringBoard/SBScrollViewItemWrapper.h
+++ b/SpringBoard/SBScrollViewItemWrapper.h
@@ -1,3 +1,5 @@
+#import <Foundation/NSObject.h>
+
 @interface SBScrollViewItemWrapper : NSObject
 
 @property (nonatomic, retain) id item;

--- a/SpringBoard/SBSearchTableViewCell.h
+++ b/SpringBoard/SBSearchTableViewCell.h
@@ -1,3 +1,5 @@
+#import <UIKit/UITableViewCell.h>
+
 @interface SBSearchTableViewCell : UITableViewCell
 
 @end

--- a/SpringBoard/SBSearchViewController.h
+++ b/SpringBoard/SBSearchViewController.h
@@ -1,3 +1,5 @@
+#import <Foundation/NSObject.h>
+
 @interface SBSearchViewController : NSObject
 
 + (instancetype)sharedInstance;

--- a/SpringBoard/SBStatusBarContentsView.h
+++ b/SpringBoard/SBStatusBarContentsView.h
@@ -1,3 +1,5 @@
+#import <Foundation/NSObject.h>
+
 @interface SBStatusBarContentsView : NSObject
 
 @end

--- a/SpringBoard/SBStatusBarDataManager.h
+++ b/SpringBoard/SBStatusBarDataManager.h
@@ -1,3 +1,5 @@
+#import <Foundation/NSObject.h>
+
 typedef struct {
     char timeString[64];
 } SBStatusBarData;

--- a/SpringBoard/SBStatusBarOperatorNameView.h
+++ b/SpringBoard/SBStatusBarOperatorNameView.h
@@ -1,3 +1,5 @@
+#import <Foundation/NSObject.h>
+
 @interface SBStatusBarOperatorNameView : NSObject
 
 @end

--- a/SpringBoard/SBStatusBarTimeView.h
+++ b/SpringBoard/SBStatusBarTimeView.h
@@ -1,3 +1,5 @@
+#import <Foundation/NSObject.h>
+
 @interface SBStatusBarTimeView : NSObject
 
 @end

--- a/SpringBoard/SBSystemGestureManager.h
+++ b/SpringBoard/SBSystemGestureManager.h
@@ -1,4 +1,3 @@
-#import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
 typedef NS_ENUM(int64_t, SBSystemGestureType) {

--- a/SpringBoard/SBSystemGestureRecognizerDelegate.h
+++ b/SpringBoard/SBSystemGestureRecognizerDelegate.h
@@ -1,3 +1,6 @@
+#import <UIKit/UIView.h>
+#import <UIKit/UIGestureRecognizer.h>
+
 @protocol SBSystemGestureRecognizerDelegate <UIGestureRecognizerDelegate>
 
 @required

--- a/SpringBoard/SBTodayBulletinCell.h
+++ b/SpringBoard/SBTodayBulletinCell.h
@@ -1,3 +1,5 @@
+#import <UIKit/UIKit.h>
+
 @interface SBTodayBulletinCell : UITableViewCell
 
 + (NSDictionary *)defaultTextAttributes;

--- a/SpringBoard/SBUIController.h
+++ b/SpringBoard/SBUIController.h
@@ -1,4 +1,3 @@
-#import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
 @class SBWallpaperView;

--- a/SpringBoard/SBWallpaperEffectView.h
+++ b/SpringBoard/SBWallpaperEffectView.h
@@ -1,4 +1,4 @@
-#import <Foundation/Foundation.h>
+#import <UIKit/UIView.h>
 
 typedef NS_ENUM(NSUInteger, SBWallpaperVariant) {
 	SBWallpaperVariantStaticWallpaper

--- a/SpringBoard/SBWallpaperPreviewSnapshotCache.h
+++ b/SpringBoard/SBWallpaperPreviewSnapshotCache.h
@@ -1,3 +1,5 @@
+#import <UIKit/UIImage.h>
+
 @interface SBWallpaperPreviewSnapshotCache : NSObject
 
 - (UIImage *)homeScreenSnapshot;

--- a/SpringBoard/SBWindowHidingManager.h
+++ b/SpringBoard/SBWindowHidingManager.h
@@ -1,4 +1,4 @@
-#import <Foundation/Foundation.h>
+#import <UIKit/UIWindow.h>
 
 @interface SBWindowHidingManager : NSObject
 

--- a/SpringBoard/SpringBoard.h
+++ b/SpringBoard/SpringBoard.h
@@ -1,4 +1,3 @@
-#import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
 @class SBApplication, SBActivationSettings;

--- a/SpringBoardFoundation/SBFWallpaperParallaxSettings.h
+++ b/SpringBoardFoundation/SBFWallpaperParallaxSettings.h
@@ -1,4 +1,5 @@
 #import <Foundation/Foundation.h>
+#import <CoreGraphics/CoreGraphics.h>
 
 @interface SBFWallpaperParallaxSettings : NSObject
 

--- a/SpringBoardHome/SBHIconGridSize.h
+++ b/SpringBoardHome/SBHIconGridSize.h
@@ -1,3 +1,5 @@
+#include <stdint.h>
+
 typedef struct SBHIconGridSize {
 	uint16_t columns;
 	uint16_t rows;

--- a/SpringBoardHome/SBIconListGridLayoutConfiguration.h
+++ b/SpringBoardHome/SBIconListGridLayoutConfiguration.h
@@ -1,4 +1,3 @@
-#import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 #import <SpringBoard/SBIconImageInfo.h>
 

--- a/SpringBoardServices/SBSApplicationShortcutIcon.h
+++ b/SpringBoardServices/SBSApplicationShortcutIcon.h
@@ -1,3 +1,5 @@
+#import <Foundation/NSObject.h>
+
 @interface SBSApplicationShortcutIcon : NSObject
 
 @end

--- a/SpringBoardServices/SBSApplicationShortcutItem.h
+++ b/SpringBoardServices/SBSApplicationShortcutItem.h
@@ -1,3 +1,7 @@
+#import <Foundation/NSObject.h>
+#import <Foundation/NSString.h>
+#import <Foundation/NSDictionary.h>
+
 @class SBSApplicationShortcutIcon;
 
 @interface SBSApplicationShortcutItem : NSObject

--- a/SpringBoardUIServices/SBPasscodeNumberPadButton.h
+++ b/SpringBoardUIServices/SBPasscodeNumberPadButton.h
@@ -1,4 +1,5 @@
-#import <Foundation/Foundation.h>
+#import <UIKit/UIView.h>
+#import <UIKit/UIImage.h>
 
 @class TPRevealingRingView;
 

--- a/SpringBoardUIServices/_SBUIWidgetHost.h
+++ b/SpringBoardUIServices/_SBUIWidgetHost.h
@@ -1,4 +1,4 @@
-#import <Foundation/Foundation.h>
+#import <UIKit/UIViewController.h>
 
 @protocol _SBUIWidgetHost
 

--- a/StoreKitUI/SKUIScrollingSegmentedController.h
+++ b/StoreKitUI/SKUIScrollingSegmentedController.h
@@ -1,3 +1,5 @@
+#import <UIKit/UIViewController.h>
+
 @interface SKUIScrollingSegmentedController : UIViewController
 
 @end

--- a/TelephonyUI/TPNumberPad.h
+++ b/TelephonyUI/TPNumberPad.h
@@ -1,3 +1,5 @@
+#import <UIKit/UIControl.h>
+
 @interface TPNumberPad : UIControl
 
 @end

--- a/TelephonyUI/TPRevealingRingView.h
+++ b/TelephonyUI/TPRevealingRingView.h
@@ -1,3 +1,5 @@
+#import <UIKit/UIView.h>
+
 @interface TPRevealingRingView : UIView
 
 @property (nonatomic, readonly) struct UIEdgeInsets paddingOutsideRing;

--- a/Tweetbot/PTHTweetbotStatus.h
+++ b/Tweetbot/PTHTweetbotStatus.h
@@ -1,3 +1,5 @@
+#import <Foundation/NSObject.h>
+
 @interface PTHTweetbotStatus : NSObject
 
 - (void)retweet:(id)sender;

--- a/Tweetbot/PTHViewController.h
+++ b/Tweetbot/PTHViewController.h
@@ -1,3 +1,5 @@
+#import <UIKit/UIViewController.h>
+
 @interface PTHViewController : UIViewController
 
 @end

--- a/TwitkaFly/LibTwitkaFly.h
+++ b/TwitkaFly/LibTwitkaFly.h
@@ -1,3 +1,5 @@
+#import <UIKit/UIImage.h>
+
 @interface LibTwitkaFly : NSObject
 
 + (instancetype)sharedTwitkaFly;

--- a/UIKit/UIActivity+Private.h
+++ b/UIKit/UIActivity+Private.h
@@ -1,5 +1,4 @@
 #import <UIKit/UIKit.h>
-#import <Foundation/Foundation.h>
 
 @interface UIActivity (Private)
 

--- a/UIKit/UIActivityGroupViewController.h
+++ b/UIKit/UIActivityGroupViewController.h
@@ -1,3 +1,5 @@
+#import <UIKit/UICollectionViewController.h>
+
 @interface UIActivityGroupViewController : UICollectionViewController
 
 @end

--- a/UIKit/UIActivityViewController+Private.h
+++ b/UIKit/UIActivityViewController+Private.h
@@ -1,3 +1,5 @@
+#import <UIKit/UIActivityViewController.h>
+
 @class _UIActivityGroupListViewController;
 
 @interface UIActivityViewController (Private)

--- a/UIKit/UIActivityViewController.h
+++ b/UIKit/UIActivityViewController.h
@@ -1,6 +1,8 @@
 #ifdef __IPHONE_6_0
 #include_next <UIKit/UIActivityViewController.h>
 #else
+#import <UIKit/UIViewController.h>
+
 @interface UIActivityViewController : UIViewController
 
 - (instancetype)initWithActivityItems:(NSArray *)items applicationActivities:(NSArray *)applicationActivities;

--- a/UIKit/UIAlertAction+Private.h
+++ b/UIKit/UIAlertAction+Private.h
@@ -1,5 +1,4 @@
 #import <UIKit/UIKit.h>
-#import <Foundation/Foundation.h>
 
 @interface UIAlertAction (Private)
 

--- a/UIKit/UIAlertController+Private.h
+++ b/UIKit/UIAlertController+Private.h
@@ -1,5 +1,4 @@
 #import <UIKit/UIKit.h>
-#import <Foundation/Foundation.h>
 
 @interface UIAlertController (Private)
 

--- a/UIKit/UIAlertView+Private.h
+++ b/UIKit/UIAlertView+Private.h
@@ -1,5 +1,4 @@
 #import <UIKit/UIKit.h>
-#import <Foundation/Foundation.h>
 
 @interface UIAlertView (Private)
 

--- a/UIKit/UIApplication+Private.h
+++ b/UIKit/UIApplication+Private.h
@@ -1,5 +1,4 @@
 #import <UIKit/UIKit.h>
-#import <Foundation/Foundation.h>
 
 @class UIStatusBar;
 

--- a/UIKit/UICollectionView.h
+++ b/UIKit/UICollectionView.h
@@ -1,8 +1,8 @@
 #ifdef __IPHONE_6_0
 #include_next <UIKit/UICollectionView.h>
 #else
-#import <Foundation/Foundation.h>
 #import "UICollectionViewCell.h"
+#import <UIKit/UIView.h>
 
 @interface UICollectionView : UIView
 

--- a/UIKit/UICollectionViewCell.h
+++ b/UIKit/UICollectionViewCell.h
@@ -1,6 +1,8 @@
 #ifdef __IPHONE_6_0
 #include_next <UIKit/UICollectionViewCell.h>
 #else
+#import <UIKit/UIView.h>
+
 @interface UICollectionViewCell : UIView
 
 @end

--- a/UIKit/UIColor+Private.h
+++ b/UIKit/UIColor+Private.h
@@ -1,5 +1,4 @@
 #import <UIKit/UIKit.h>
-#import <CoreGraphics/CoreGraphics.h>
 
 @interface UIColor (Private)
 

--- a/UIKit/UICompatibilityInputViewController.h
+++ b/UIKit/UICompatibilityInputViewController.h
@@ -1,4 +1,5 @@
 #import "UIKeyboardInputMode.h"
+#import <UIKit/UIInputViewController.h>
 
 @interface UICompatibilityInputViewController : UIInputViewController
 

--- a/UIKit/UIDebuggingInformationOverlay.h
+++ b/UIKit/UIDebuggingInformationOverlay.h
@@ -1,3 +1,5 @@
+#import <UIKit/UIWindow.h>
+
 @interface UIDebuggingInformationOverlay : UIWindow
 
 + (instancetype)overlay;

--- a/UIKit/UIDevice+Private.h
+++ b/UIKit/UIDevice+Private.h
@@ -1,4 +1,3 @@
-#import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
 @interface UIDevice (Private)

--- a/UIKit/UIImage+Private.h
+++ b/UIKit/UIImage+Private.h
@@ -1,5 +1,4 @@
 #import <UIKit/UIKit.h>
-#import <Foundation/Foundation.h>
 #import <MobileIcons/MobileIcons.h>
 
 @class LSApplicationProxy;

--- a/UIKit/UIInputViewAnimationStyle.h
+++ b/UIKit/UIInputViewAnimationStyle.h
@@ -1,3 +1,5 @@
+#import <Foundation/NSObject.h>
+
 @interface UIInputViewAnimationStyle : NSObject
 
 @property BOOL force;

--- a/UIKit/UIInputViewController+Private.h
+++ b/UIKit/UIInputViewController+Private.h
@@ -1,4 +1,5 @@
 #import "UICompatibilityInputViewController.h"
+#import <UIKit/UIInputViewController.h>
 
 @interface UIInputViewController (Private)
 

--- a/UIKit/UIInputViewSet.h
+++ b/UIKit/UIInputViewSet.h
@@ -1,4 +1,4 @@
-#import <Foundation/Foundation.h>
+#import <UIKit/UIInputViewController.h>
 
 @interface UIInputViewSet : NSObject
 

--- a/UIKit/UIKBGradient.h
+++ b/UIKit/UIKBGradient.h
@@ -1,3 +1,5 @@
+#import <Foundation/NSObject.h>
+#import <Foundation/NSString.h>
 #import <CoreGraphics/CoreGraphics.h>
 
 @interface UIKBGradient : NSObject

--- a/UIKit/UIKBInputBackdropView.h
+++ b/UIKit/UIKBInputBackdropView.h
@@ -1,3 +1,5 @@
+#import <UIKit/UIView.h>
+
 @interface UIKBInputBackdropView : UIView
 
 - (void)layoutInputBackdropToFullWithRect:(CGRect)rect;

--- a/UIKit/UIKBKeyView.h
+++ b/UIKit/UIKBKeyView.h
@@ -1,5 +1,6 @@
 #import "UIKBTree.h"
 #import "UIKBRenderConfig.h"
+#import <UIKit/UIView.h>
 
 @interface UIKBKeyView : UIView {
     UIKBTree *m_key;

--- a/UIKit/UIKBKeyplaneView.h
+++ b/UIKit/UIKBKeyplaneView.h
@@ -1,4 +1,5 @@
 #import "UIKBTree.h"
+#import <UIKit/UIView.h>
 
 @interface UIKBKeyplaneView : UIView
 

--- a/UIKit/UIKBRenderConfig.h
+++ b/UIKit/UIKBRenderConfig.h
@@ -1,4 +1,5 @@
 #import "UIKeyboardInputMode.h"
+#import <CoreGraphics/CoreGraphics.h>
 
 @interface UIKBRenderConfig : NSObject
 

--- a/UIKit/UIKBScreenTraits.h
+++ b/UIKit/UIKBScreenTraits.h
@@ -1,4 +1,4 @@
-#import <Foundation/Foundation.h>
+#import <UIKit/UIScreen.h>
 
 @interface UIKBScreenTraits : NSObject
 

--- a/UIKit/UIKeyboardLayout.h
+++ b/UIKit/UIKeyboardLayout.h
@@ -1,4 +1,4 @@
-#import <CoreGraphics/CoreGraphics.h>
+#import <UIKit/UIView.h>
 
 @class UIKBRenderConfig;
 

--- a/UIKit/UIKeyboardPreferencesController.h
+++ b/UIKit/UIKeyboardPreferencesController.h
@@ -1,3 +1,7 @@
+#import <Foundation/NSObject.h>
+#import <Foundation/NSObjCRuntime.h>
+#import <CoreGraphics/CoreGraphics.h>
+
 @interface UIKeyboardPreferencesController : NSObject
 + (instancetype)sharedPreferencesController;
 

--- a/UIKit/UIKeyboardTouchInfo.h
+++ b/UIKit/UIKeyboardTouchInfo.h
@@ -1,4 +1,5 @@
 #import "UIKBTree.h"
+#import <UIKit/UITouch.h>
 
 @interface UIKeyboardTouchInfo : NSObject
 

--- a/UIKit/UINavigationBar+Private.h
+++ b/UIKit/UINavigationBar+Private.h
@@ -1,4 +1,4 @@
-#import <Foundation/Foundation.h>
+#import <UIKit/UINavigationBar.h>
 
 @interface UINavigationBar (Private)
 

--- a/UIKit/UIPanGestureRecognizer+Private.h
+++ b/UIKit/UIPanGestureRecognizer+Private.h
@@ -1,3 +1,5 @@
+#import <UIKit/UIPanGestureRecognizer.h>
+
 @interface UIPanGestureRecognizer (Private)
 
 @property (setter=_setHysteresis:) CGFloat _hysteresis;

--- a/UIKit/UIPeripheralHost.h
+++ b/UIKit/UIPeripheralHost.h
@@ -1,4 +1,5 @@
 #import "UIKBRenderConfig.h"
+#import <UIKit/UIKit.h>
 
 @interface UIPeripheralHost : NSObject
 

--- a/UIKit/UIPeripheralHostView.h
+++ b/UIKit/UIPeripheralHostView.h
@@ -1,4 +1,5 @@
 #import "UIInputViewSet.h"
+#import <UIKit/UIKit.h>
 
 @interface UIPeripheralHostView : UIView
 

--- a/UIKit/UIProgressHUD.h
+++ b/UIKit/UIProgressHUD.h
@@ -1,3 +1,5 @@
+#import <UIKit/UIView.h>
+
 @interface UIProgressHUD : UIView
 
 @end

--- a/UIKit/UIProgressIndicator.h
+++ b/UIKit/UIProgressIndicator.h
@@ -1,3 +1,5 @@
+#import <UIKit/UIActivityIndicatorView.h>
+
 @interface UIProgressIndicator : UIActivityIndicatorView
 
 @end

--- a/UIKit/UIResponder+Private.h
+++ b/UIKit/UIResponder+Private.h
@@ -1,3 +1,5 @@
+#import <UIKit/UIResponder.h>
+
 @interface UIResponder (Private)
 
 - (BOOL)_requiresKeyboardWhenFirstResponder;

--- a/UIKit/UIScreen+Private.h
+++ b/UIKit/UIScreen+Private.h
@@ -1,5 +1,4 @@
 #import <UIKit/UIKit.h>
-#import <Foundation/Foundation.h>
 
 @interface UIScreen (Private)
 

--- a/UIKit/UIStatusBar.h
+++ b/UIKit/UIStatusBar.h
@@ -1,4 +1,4 @@
-#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 @class UIStatusBarForegroundStyleAttributes, UIStatusBarForegroundView;
 

--- a/UIKit/UIStatusBarAnimationParameters.h
+++ b/UIKit/UIStatusBarAnimationParameters.h
@@ -1,3 +1,5 @@
+#import <Foundation/NSObject.h>
+
 @interface UIStatusBarAnimationParameters : NSObject
 
 + (void)animateWithParameters:(UIStatusBarAnimationParameters *)parameters animations:(void (^)(void))animations completion:(void (^)(BOOL finished))completion;

--- a/UIKit/UIStatusBarForegroundView.h
+++ b/UIKit/UIStatusBarForegroundView.h
@@ -1,3 +1,5 @@
+#import <UIKit/UIView.h>
+
 @class UIStatusBarForegroundStyleAttributes;
 
 @interface UIStatusBarForegroundView : UIView

--- a/UIKit/UIStatusBarItem.h
+++ b/UIKit/UIStatusBarItem.h
@@ -1,4 +1,4 @@
-#import <Foundation/Foundation.h>
+#import <UIKit/UIDevice.h>
 
 // this enum was reversed out of iOS 10.2, not clear if it's ABI stable
 typedef enum {

--- a/UIKit/UIStatusBarItemView.h
+++ b/UIKit/UIStatusBarItemView.h
@@ -1,4 +1,4 @@
-#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 typedef NS_ENUM(NSUInteger, UIStatusBarItemViewTextStyle) {
 	UIStatusBarItemViewTextStyleRegular = 1,

--- a/UIKit/UITableView+Private.h
+++ b/UIKit/UITableView+Private.h
@@ -1,3 +1,6 @@
+#import <UIKit/UITableView.h>
+#import <UIKit/UIView.h>
+
 @interface UITableView (Private)
 
 @property (setter=_setMarginWidth:) CGFloat _marginWidth;

--- a/UIKit/UITableViewCell+Private.h
+++ b/UIKit/UITableViewCell+Private.h
@@ -1,4 +1,4 @@
-#import <UIKit/UIKit.h>
+#import <UIKit/UITableViewCell.h>
 
 @interface UITableViewCell (Private)
 

--- a/UIKit/UITableViewHeaderFooterView.h
+++ b/UIKit/UITableViewHeaderFooterView.h
@@ -1,6 +1,8 @@
 #ifdef __IPHONE_6_0
 #include_next <UIKit/UITableViewHeaderFooterView.h>
 #else
+#import <UIKit/UITableViewCell.h>
+
 @interface UITableViewHeaderFooterView : UITableViewCell
 
 @end

--- a/UIKit/UITextInputController.h
+++ b/UIKit/UITextInputController.h
@@ -1,5 +1,4 @@
 #import <UIKit/UIKit.h>
-#import <Foundation/Foundation.h>
 
 @interface UITextInputController : NSObject
 

--- a/UIKit/UIWindow+Private.h
+++ b/UIKit/UIWindow+Private.h
@@ -1,4 +1,3 @@
-#import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
 #define UIWindowLevelNotificationCenter 1056.f

--- a/UIKit/_UIActivityGroupListViewController.h
+++ b/UIKit/_UIActivityGroupListViewController.h
@@ -1,3 +1,5 @@
+#import <UIKit/UICollectionViewController.h>
+
 @interface _UIActivityGroupListViewController : UICollectionViewController
 
 @property (nonatomic, copy) NSArray *activityGroupViewControllers;

--- a/UIKit/_UIBackdropEffectView.h
+++ b/UIKit/_UIBackdropEffectView.h
@@ -1,3 +1,5 @@
+#import <UIKit/UIView.h>
+
 @interface _UIBackdropEffectView : UIView
 
 @end

--- a/UIKit/_UIBackdropView.h
+++ b/UIKit/_UIBackdropView.h
@@ -1,6 +1,4 @@
 #import <UIKit/UIKit.h>
-#import <Foundation/Foundation.h>
-#import <CoreGraphics/CoreGraphics.h>
 
 @class _UIBackdropViewSettings, _UIBackdropEffectView, CABackdropLayer;
 

--- a/UIKit/_UIHostedWindowHostingHandle.h
+++ b/UIKit/_UIHostedWindowHostingHandle.h
@@ -1,4 +1,5 @@
 #import <Foundation/Foundation.h>
+#import <CoreGraphics/CoreGraphics.h>
 
 API_AVAILABLE(ios(7.0))
 @interface _UIHostedWindowHostingHandle : NSObject <NSSecureCoding>

--- a/UIKit/_UILegibilityImageSet.h
+++ b/UIKit/_UILegibilityImageSet.h
@@ -1,3 +1,5 @@
+#import <UIKit/UIImage.h>
+
 @interface _UILegibilityImageSet : NSObject
 
 + (instancetype)imageFromImage:(UIImage *)image withShadowImage:(UIImage *)shadowImage;

--- a/UIKit/_UILegibilitySettings.h
+++ b/UIKit/_UILegibilitySettings.h
@@ -1,3 +1,5 @@
+#import <UIKit/UIColor.h>
+
 @interface _UILegibilitySettings : NSObject
 
 @property (retain) UIColor *contentColor;

--- a/UIKit/_UILegibilityView.h
+++ b/UIKit/_UILegibilityView.h
@@ -1,4 +1,5 @@
 #import "_UILegibilitySettings.h"
+#import <UIKit/UIView.h>
 
 @interface _UILegibilityView : UIView
 

--- a/UIKit/_UIModalItemBackgroundView.h
+++ b/UIKit/_UIModalItemBackgroundView.h
@@ -1,3 +1,5 @@
+#import <UIKit/UIView.h>
+
 @interface _UIModalItemBackgroundView : UIView
 
 @end

--- a/UIKit/_UIModalItemContentView.h
+++ b/UIKit/_UIModalItemContentView.h
@@ -1,3 +1,6 @@
+#import <UIKit/UILabel.h>
+#import <UIKit/UILabel.h>
+
 @interface _UIModalItemContentView : UIView
 
 @property (readonly, nonatomic) UILabel *messageLabel;

--- a/UIKit/_UIModalItemContentView.h
+++ b/UIKit/_UIModalItemContentView.h
@@ -1,5 +1,4 @@
 #import <UIKit/UILabel.h>
-#import <UIKit/UILabel.h>
 
 @interface _UIModalItemContentView : UIView
 

--- a/UIKit/_UIModalItemTableViewCell.h
+++ b/UIKit/_UIModalItemTableViewCell.h
@@ -1,3 +1,5 @@
+#import <UIKit/UITableViewCell.h>
+
 @interface _UIModalItemTableViewCell : UITableViewCell
 
 @end

--- a/UserNotificationsKit/NCNotificationRequest.h
+++ b/UserNotificationsKit/NCNotificationRequest.h
@@ -1,3 +1,6 @@
+#import <Foundation/NSObject.h>
+#import <Foundation/NSString.h>
+
 @interface NCNotificationRequest : NSObject
 
 @property (nonatomic, copy, readonly) NSString *sectionIdentifier;

--- a/UserNotificationsUIKit/NCAnimatableBlurringView.h
+++ b/UserNotificationsUIKit/NCAnimatableBlurringView.h
@@ -1,3 +1,5 @@
+#import <UIKit/UIView.h>
+
 @interface NCAnimatableBlurringView : UIView
 
 @end

--- a/UserNotificationsUIKit/NCMaterialView.h
+++ b/UserNotificationsUIKit/NCMaterialView.h
@@ -1,3 +1,5 @@
+#import <UIKit/UIView.h>
+
 @interface NCMaterialView : UIView
 
 @end

--- a/UserNotificationsUIKit/NCNotificationStaticContentProviding.h
+++ b/UserNotificationsUIKit/NCNotificationStaticContentProviding.h
@@ -1,3 +1,5 @@
+#import <UIKit/UIImage.h>
+
 @protocol NCNotificationStaticContentProviding <NSObject>
 
 - (UIImage *)icon;

--- a/UserNotificationsUIKit/NCNotificationViewController.h
+++ b/UserNotificationsUIKit/NCNotificationViewController.h
@@ -1,3 +1,6 @@
+#import <UIKit/UIViewController.h>
+#import <UIKit/UIView.h>
+
 @class NCNotificationRequest;
 @protocol NCNotificationStaticContentProviding;
 

--- a/UserNotificationsUIKit/NCShortLookView.h
+++ b/UserNotificationsUIKit/NCShortLookView.h
@@ -1,3 +1,5 @@
+#import <UIKit/UIView.h>
+
 @interface NCShortLookView : UIView
 
 @end

--- a/Velox/VeloxFolderViewProtocol.h
+++ b/Velox/VeloxFolderViewProtocol.h
@@ -1,3 +1,5 @@
+#import <CoreGraphics/CoreGraphics.h>
+
 @protocol VeloxFolderViewProtocol
 
 + (int)folderHeight;

--- a/auki/KJUARR.h
+++ b/auki/KJUARR.h
@@ -1,3 +1,6 @@
+#import <Foundation/NSObject.h>
+#import <Foundation/NSArray.h>
+
 @class BBBulletin;
 
 @interface KJUARR : NSObject

--- a/installd/MIBundle.h
+++ b/installd/MIBundle.h
@@ -1,3 +1,11 @@
+#import <Foundation/NSObject.h>
+#import <Foundation/NSError.h>
+#import <Foundation/NSURL.h>
+#import <Foundation/NSString.h>
+#import <Foundation/NSObjCRuntime.h>
+#import <Foundation/NSArray.h>
+#import <Foundation/NSDictionary.h>
+
 typedef NS_ENUM(NSInteger, MIBundleType) {
 	MIBundleTypeSystemApp = 1,
 	MIBundleTypeInternalApp,

--- a/installd/MIGlobalConfiguration.h
+++ b/installd/MIGlobalConfiguration.h
@@ -1,3 +1,5 @@
+#import <Foundation/NSObject.h>
+
 @interface MIGlobalConfiguration : NSObject
 
 @end

--- a/libstatusbar/LSStatusBarItem.h
+++ b/libstatusbar/LSStatusBarItem.h
@@ -1,3 +1,5 @@
+#import <Foundation/Foundation.h>
+
 typedef enum
 {
 	StatusBarAlignmentLeft = 1,

--- a/libundirect/libundirect_dynamic.h
+++ b/libundirect/libundirect_dynamic.h
@@ -11,7 +11,7 @@
 // copies or substantial portions of the Software.
 
 #import <objc/objc.h>
-#import <sys/unistd.h>
+#import <unistd.h>
 #import <dlfcn.h>
 #import <Foundation/NSString.h>
 #import <substrate.h>

--- a/libundirect/libundirect_dynamic.h
+++ b/libundirect/libundirect_dynamic.h
@@ -11,7 +11,6 @@
 // copies or substantial portions of the Software.
 
 #import <objc/objc.h>
-#import <sys/unistd.h>
 #import <dlfcn.h>
 #import <unistd.h>
 #import <Foundation/NSString.h>

--- a/libundirect/libundirect_dynamic.h
+++ b/libundirect/libundirect_dynamic.h
@@ -11,8 +11,8 @@
 // copies or substantial portions of the Software.
 
 #import <objc/objc.h>
+#import <sys/unistd.h>
 #import <dlfcn.h>
-#import <unistd.h>
 #import <Foundation/NSString.h>
 #import <substrate.h>
 #import <libhooker/libhooker.h>

--- a/libundirect/libundirect_dynamic.h
+++ b/libundirect/libundirect_dynamic.h
@@ -13,6 +13,8 @@
 #import <objc/objc.h>
 #import <sys/unistd.h>
 #import <dlfcn.h>
+#import <unistd.h>
+#import <Foundation/NSString.h>
 #import <substrate.h>
 #import <libhooker/libhooker.h>
 
@@ -25,8 +27,8 @@ extern "C" {
 // dynamic header for when you don't want to link against libundirect
 // for documentation, check out the non-dynamic header
 
-typedef enum 
-{ 
+typedef enum
+{
     OPTION_DO_NOT_SEEK_BACK = 1 << 0
 } libundirect_find_options_t;
 

--- a/sandbox.h
+++ b/sandbox.h
@@ -1,5 +1,7 @@
-#include_next <sandbox.h>
+// #include_next <sandbox.h>
 #include <mach/message.h>
+#include <stdio.h>
+#include <unistd.h>
 
 // courtesy of clang
 // https://github.com/applesrc/clang/blob/bb8f644/src/projects/compiler-rt/lib/sanitizer_common/sanitizer_mac_spi.cc

--- a/sandbox.h
+++ b/sandbox.h
@@ -1,4 +1,6 @@
-#include_next <sandbox.h>
+#if __has_include_next(<sandbox.h>)
+#   include_next <sandbox.h>
+#endif
 #include <mach/message.h>
 #include <stdio.h>
 #include <unistd.h>

--- a/sandbox.h
+++ b/sandbox.h
@@ -1,4 +1,4 @@
-// #include_next <sandbox.h>
+#include_next <sandbox.h>
 #include <mach/message.h>
 #include <stdio.h>
 #include <unistd.h>

--- a/theos/IOSMacros.h
+++ b/theos/IOSMacros.h
@@ -1,5 +1,4 @@
 #import <UIKit/UIKit.h>
-#import <Foundation/Foundation.h>
 
 #define IS_IPAD ([UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPad)
 #define IN_SPRINGBOARD ([[NSBundle mainBundle].bundleIdentifier isEqualToString:@"com.apple.springboard"])


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link below to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
See title

Checklist
---------
- [ ] New code follows the [code rules](https://github.com/theos/headers/blob/master/README.md#code-rules)
- [ ] I've added modulemaps for any new libraries (e.g. see [libactivator/module.modulemap](https://github.com/theos/headers/blob/f3e596d896bae8f07c43cfb00ef55bf6224b4cdc/libactivator/module.modulemap)): it should be possible to `@import MyLibrary;` in ObjC, or `import MyLibrary` in Swift.
- [ ] My contribution is code written by myself from reverse-engineered headers, licensed into the Public Domain as per [LICENSE.md](LICENSE.md); or, code written by myself / taken from an existing project, released under an OSI-approved license, and I've added relevant licensing credit to [LICENSE.md](LICENSE.md)


Does this close any currently open issues?
------------------------------------------
…

Any relevant logs, error output, etc?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
- See successful CI [here](https://github.com/L1ghtmann/headers/actions/runs/6921140268/job/18826391439)
- Supersedes #88  

Where has this been tested?
---------------------------
**Operating System:** …

Linux & OSX GitHub-hosted runners

**Platform:** …

**Target Platform:** …

**Toolchain Version:** …

**SDK Version:** …
