### PR TITLE
[libroot] Add interface-only swiftmodule for libroot

### DIFF
--- a/libroot.swiftmodule/arm64-apple-ios.swiftinterface
+++ b/libroot.swiftmodule/arm64-apple-ios.swiftinterface
@@ -5,14 +5,10 @@ import Foundation
 import Swift
 @_exported import libroot
 @_alwaysEmitIntoClient public func jbRootPath(_ cPath: Swift.UnsafePointer<Swift.CChar>?) -> Swift.String {
-    let stringElements: [String.Element] = .init(unsafeUninitializedCapacity: Int(PATH_MAX)) { buffer, initializedCount in
-        if let resolved = libroot_dyn_jbrootpath(cPath, buffer.baseAddress) {
-            initializedCount = strlen(resolved)
-        } else {
-            initializedCount = 0
-        }
-    }
-    return String(stringElements)
+    guard let resolved = libroot_dyn_jbrootpath(cPath, nil) else { return "" }
+    let result = String(cString: resolved)
+    free(resolved)
+    return result
 }
 @_alwaysEmitIntoClient @_disfavoredOverload public func jbRootPath<S>(_ path: S) -> Swift.String where S : Swift.StringProtocol {
     path.withCString { cPath in
@@ -20,14 +16,10 @@ import Swift
     }
 }
 @_alwaysEmitIntoClient public func rootFsPath(_ cPath: Swift.UnsafePointer<Swift.CChar>?) -> Swift.String {
-    let stringElements: [String.Element] = .init(unsafeUninitializedCapacity: Int(PATH_MAX)) { buffer, initializedCount in
-        if let resolved = libroot_dyn_rootfspath(cPath, buffer.baseAddress) {
-            initializedCount = strlen(resolved)
-        } else {
-            initializedCount = 0
-        }
-    }
-    return String(stringElements)
+    guard let resolved = libroot_dyn_rootfspath(cPath, nil) else { return "" }
+    let result = String(cString: resolved)
+    free(resolved)
+    return result
 }
 @_alwaysEmitIntoClient @_disfavoredOverload public func rootFsPath<S>(_ path: S) -> Swift.String where S : Swift.StringProtocol {
     path.withCString { cPath in

--- a/libroot.swiftmodule/arm64-apple-ios.swiftinterface
+++ b/libroot.swiftmodule/arm64-apple-ios.swiftinterface
@@ -1,0 +1,36 @@
+// swift-interface-format-version: 1.0
+// swift-compiler-version: Apple Swift version 5.6.1 (swiftlang-5.6.0.323.66 clang-1316.0.20.12)
+// swift-module-flags: -target arm64-apple-ios7.0 -enable-objc-interop -enable-library-evolution -module-name libroot
+import Foundation
+import Swift
+@_exported import libroot
+@_alwaysEmitIntoClient public func jbRootPath(_ cPath: Swift.UnsafePointer<Swift.CChar>?) -> Swift.String {
+    let stringElements: [String.Element] = .init(unsafeUninitializedCapacity: Int(PATH_MAX)) { buffer, initializedCount in
+        if let resolved = libroot_dyn_jbrootpath(cPath, buffer.baseAddress) {
+            initializedCount = strlen(resolved)
+        } else {
+            initializedCount = 0
+        }
+    }
+    return String(stringElements)
+}
+@_alwaysEmitIntoClient @_disfavoredOverload public func jbRootPath<S>(_ path: S) -> Swift.String where S : Swift.StringProtocol {
+    path.withCString { cPath in
+        jbRootPath(cPath)
+    }
+}
+@_alwaysEmitIntoClient public func rootFsPath(_ cPath: Swift.UnsafePointer<Swift.CChar>?) -> Swift.String {
+    let stringElements: [String.Element] = .init(unsafeUninitializedCapacity: Int(PATH_MAX)) { buffer, initializedCount in
+        if let resolved = libroot_dyn_rootfspath(cPath, buffer.baseAddress) {
+            initializedCount = strlen(resolved)
+        } else {
+            initializedCount = 0
+        }
+    }
+    return String(stringElements)
+}
+@_alwaysEmitIntoClient @_disfavoredOverload public func rootFsPath<S>(_ path: S) -> Swift.String where S : Swift.StringProtocol {
+    path.withCString { cPath in
+        rootFsPath(cPath)
+    }
+}

--- a/libroot.swiftmodule/arm64e-apple-ios.swiftinterface
+++ b/libroot.swiftmodule/arm64e-apple-ios.swiftinterface
@@ -5,14 +5,10 @@ import Foundation
 import Swift
 @_exported import libroot
 @_alwaysEmitIntoClient public func jbRootPath(_ cPath: Swift.UnsafePointer<Swift.CChar>?) -> Swift.String {
-    let stringElements: [String.Element] = .init(unsafeUninitializedCapacity: Int(PATH_MAX)) { buffer, initializedCount in
-        if let resolved = libroot_dyn_jbrootpath(cPath, buffer.baseAddress) {
-            initializedCount = strlen(resolved)
-        } else {
-            initializedCount = 0
-        }
-    }
-    return String(stringElements)
+    guard let resolved = libroot_dyn_jbrootpath(cPath, nil) else { return "" }
+    let result = String(cString: resolved)
+    free(resolved)
+    return result
 }
 @_alwaysEmitIntoClient @_disfavoredOverload public func jbRootPath<S>(_ path: S) -> Swift.String where S : Swift.StringProtocol {
     path.withCString { cPath in
@@ -20,14 +16,10 @@ import Swift
     }
 }
 @_alwaysEmitIntoClient public func rootFsPath(_ cPath: Swift.UnsafePointer<Swift.CChar>?) -> Swift.String {
-    let stringElements: [String.Element] = .init(unsafeUninitializedCapacity: Int(PATH_MAX)) { buffer, initializedCount in
-        if let resolved = libroot_dyn_rootfspath(cPath, buffer.baseAddress) {
-            initializedCount = strlen(resolved)
-        } else {
-            initializedCount = 0
-        }
-    }
-    return String(stringElements)
+    guard let resolved = libroot_dyn_rootfspath(cPath, nil) else { return "" }
+    let result = String(cString: resolved)
+    free(resolved)
+    return result
 }
 @_alwaysEmitIntoClient @_disfavoredOverload public func rootFsPath<S>(_ path: S) -> Swift.String where S : Swift.StringProtocol {
     path.withCString { cPath in

--- a/libroot.swiftmodule/arm64e-apple-ios.swiftinterface
+++ b/libroot.swiftmodule/arm64e-apple-ios.swiftinterface
@@ -1,0 +1,36 @@
+// swift-interface-format-version: 1.0
+// swift-compiler-version: Apple Swift version 5.6.1 (swiftlang-5.6.0.323.66 clang-1316.0.20.12)
+// swift-module-flags: -target arm64e-apple-ios7.0 -enable-objc-interop -enable-library-evolution -module-name libroot
+import Foundation
+import Swift
+@_exported import libroot
+@_alwaysEmitIntoClient public func jbRootPath(_ cPath: Swift.UnsafePointer<Swift.CChar>?) -> Swift.String {
+    let stringElements: [String.Element] = .init(unsafeUninitializedCapacity: Int(PATH_MAX)) { buffer, initializedCount in
+        if let resolved = libroot_dyn_jbrootpath(cPath, buffer.baseAddress) {
+            initializedCount = strlen(resolved)
+        } else {
+            initializedCount = 0
+        }
+    }
+    return String(stringElements)
+}
+@_alwaysEmitIntoClient @_disfavoredOverload public func jbRootPath<S>(_ path: S) -> Swift.String where S : Swift.StringProtocol {
+    path.withCString { cPath in
+        jbRootPath(cPath)
+    }
+}
+@_alwaysEmitIntoClient public func rootFsPath(_ cPath: Swift.UnsafePointer<Swift.CChar>?) -> Swift.String {
+    let stringElements: [String.Element] = .init(unsafeUninitializedCapacity: Int(PATH_MAX)) { buffer, initializedCount in
+        if let resolved = libroot_dyn_rootfspath(cPath, buffer.baseAddress) {
+            initializedCount = strlen(resolved)
+        } else {
+            initializedCount = 0
+        }
+    }
+    return String(stringElements)
+}
+@_alwaysEmitIntoClient @_disfavoredOverload public func rootFsPath<S>(_ path: S) -> Swift.String where S : Swift.StringProtocol {
+    path.withCString { cPath in
+        rootFsPath(cPath)
+    }
+}

--- a/libroot.swiftmodule/armv7-apple-ios.swiftinterface
+++ b/libroot.swiftmodule/armv7-apple-ios.swiftinterface
@@ -5,14 +5,10 @@ import Foundation
 import Swift
 @_exported import libroot
 @_alwaysEmitIntoClient public func jbRootPath(_ cPath: Swift.UnsafePointer<Swift.CChar>?) -> Swift.String {
-    let stringElements: [String.Element] = .init(unsafeUninitializedCapacity: Int(PATH_MAX)) { buffer, initializedCount in
-        if let resolved = libroot_dyn_jbrootpath(cPath, buffer.baseAddress) {
-            initializedCount = strlen(resolved)
-        } else {
-            initializedCount = 0
-        }
-    }
-    return String(stringElements)
+    guard let resolved = libroot_dyn_jbrootpath(cPath, nil) else { return "" }
+    let result = String(cString: resolved)
+    free(resolved)
+    return result
 }
 @_alwaysEmitIntoClient @_disfavoredOverload public func jbRootPath<S>(_ path: S) -> Swift.String where S : Swift.StringProtocol {
     path.withCString { cPath in
@@ -20,14 +16,10 @@ import Swift
     }
 }
 @_alwaysEmitIntoClient public func rootFsPath(_ cPath: Swift.UnsafePointer<Swift.CChar>?) -> Swift.String {
-    let stringElements: [String.Element] = .init(unsafeUninitializedCapacity: Int(PATH_MAX)) { buffer, initializedCount in
-        if let resolved = libroot_dyn_rootfspath(cPath, buffer.baseAddress) {
-            initializedCount = strlen(resolved)
-        } else {
-            initializedCount = 0
-        }
-    }
-    return String(stringElements)
+    guard let resolved = libroot_dyn_rootfspath(cPath, nil) else { return "" }
+    let result = String(cString: resolved)
+    free(resolved)
+    return result
 }
 @_alwaysEmitIntoClient @_disfavoredOverload public func rootFsPath<S>(_ path: S) -> Swift.String where S : Swift.StringProtocol {
     path.withCString { cPath in

--- a/libroot.swiftmodule/armv7-apple-ios.swiftinterface
+++ b/libroot.swiftmodule/armv7-apple-ios.swiftinterface
@@ -1,0 +1,36 @@
+// swift-interface-format-version: 1.0
+// swift-compiler-version: Apple Swift version 5.6.1 (swiftlang-5.6.0.323.66 clang-1316.0.20.12)
+// swift-module-flags: -target armv7-apple-ios7.0 -enable-objc-interop -enable-library-evolution -module-name libroot
+import Foundation
+import Swift
+@_exported import libroot
+@_alwaysEmitIntoClient public func jbRootPath(_ cPath: Swift.UnsafePointer<Swift.CChar>?) -> Swift.String {
+    let stringElements: [String.Element] = .init(unsafeUninitializedCapacity: Int(PATH_MAX)) { buffer, initializedCount in
+        if let resolved = libroot_dyn_jbrootpath(cPath, buffer.baseAddress) {
+            initializedCount = strlen(resolved)
+        } else {
+            initializedCount = 0
+        }
+    }
+    return String(stringElements)
+}
+@_alwaysEmitIntoClient @_disfavoredOverload public func jbRootPath<S>(_ path: S) -> Swift.String where S : Swift.StringProtocol {
+    path.withCString { cPath in
+        jbRootPath(cPath)
+    }
+}
+@_alwaysEmitIntoClient public func rootFsPath(_ cPath: Swift.UnsafePointer<Swift.CChar>?) -> Swift.String {
+    let stringElements: [String.Element] = .init(unsafeUninitializedCapacity: Int(PATH_MAX)) { buffer, initializedCount in
+        if let resolved = libroot_dyn_rootfspath(cPath, buffer.baseAddress) {
+            initializedCount = strlen(resolved)
+        } else {
+            initializedCount = 0
+        }
+    }
+    return String(stringElements)
+}
+@_alwaysEmitIntoClient @_disfavoredOverload public func rootFsPath<S>(_ path: S) -> Swift.String where S : Swift.StringProtocol {
+    path.withCString { cPath in
+        rootFsPath(cPath)
+    }
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link below to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Provide a Swift wrapper for libroot.

Since libroot will be widely used and Swift is a popular language to use with theos, I think providing a Swift interface for libroot is helpful.

This is implemented with `@_alwaysEmitIntoClient` so it effectively works like a `.a` library: if the functions are referenced, the functions will be pulled into the client.

The original source for this module is https://github.com/leptos-null/libroot-swift

Checklist
---------
- [x] New code follows the [code rules](https://github.com/theos/headers/blob/master/README.md#code-rules)
- [x] I've added modulemaps for any new libraries (e.g. see [libactivator/module.modulemap](https://github.com/theos/headers/blob/f3e596d896bae8f07c43cfb00ef55bf6224b4cdc/libactivator/module.modulemap)): it should be possible to `@import MyLibrary;` in ObjC, or `import MyLibrary` in Swift.
- [x] My contribution is code written by myself from reverse-engineered headers, licensed into the Public Domain as per [LICENSE.md](LICENSE.md); or, code written by myself / taken from an existing project, released under an OSI-approved license, and I've added relevant licensing credit to [LICENSE.md](LICENSE.md)


Does this close any currently open issues?
------------------------------------------
no

Any relevant logs, error output, etc?
-------------------------------------
no

Any other comments?
-------------------

Sample project:

- `Makefile`
  ```make
  TARGET := iphone:clang:16.5:14.0
  
  include $(THEOS)/makefiles/common.mk
  
  TOOL_NAME = sampletool
  
  sampletool_FILES = main.swift
  sampletool_INSTALL_PATH = /usr/local/bin
  
  include $(THEOS_MAKE_PATH)/tool.mk
  ```

- `main.swift`
  ```swift
  import libroot
  
  print("rootFsPath", rootFsPath("/System/Library"))
  print("jbRootPath", jbRootPath("/Library"))
  ```

Where has this been tested?
---------------------------
**Operating System:** macOS

**Platform:** Darwin

**Target Platform:** iPhoneOS

**Toolchain Version:** `swift-driver version: 1.90.11.1 Apple Swift version 5.10 (swiftlang-5.10.0.13 clang-1500.3.9.4)`

**SDK Version:** 14.5, 15.6, 16.5
