### PR TITLE
Update to latest libroot (commit 102348f)

### DIFF
--- a/libroot/libroot.h
+++ b/libroot/libroot.h
@@ -2,25 +2,17 @@
 
 __BEGIN_DECLS
 
+_Pragma("GCC visibility push(hidden)")
+
 const char *_Nonnull libroot_dyn_get_root_prefix(void);
 const char *_Nonnull libroot_dyn_get_jbroot_prefix(void);
 const char *_Nonnull libroot_dyn_get_boot_uuid(void);
 char *_Nullable libroot_dyn_rootfspath(const char *_Nullable path, char *_Nullable resolvedPath);
 char *_Nullable libroot_dyn_jbrootpath(const char *_Nullable path, char *_Nullable resolvedPath);
 
+_Pragma("GCC visibility pop")
+
 __END_DECLS
-
-#ifdef __OBJC__
-
-#define __CONVERT_PATH_NSSTRING(converter, path) ({ \
-	char tmpBuf[PATH_MAX]; \
-	[NSString stringWithUTF8String:converter(path.fileSystemRepresentation, tmpBuf)]; \
-})
-
-#define JBROOT_PATH_NSSTRING(path) __CONVERT_PATH_NSSTRING(libroot_dyn_jbrootpath, path)
-#define ROOTFS_PATH_NSSTRING(path) __CONVERT_PATH_NSSTRING(libroot_dyn_rootfspath, path)
-
-#endif /* __OBJC__ */
 
 #define __CONVERT_PATH_CSTRING(converter, path) ({ \
 	static char outPath[PATH_MAX]; \
@@ -29,5 +21,50 @@ __END_DECLS
 
 #define JBROOT_PATH_CSTRING(path) __CONVERT_PATH_CSTRING(libroot_dyn_jbrootpath, path)
 #define ROOTFS_PATH_CSTRING(path) __CONVERT_PATH_CSTRING(libroot_dyn_rootfspath, path)
+
+#if __has_attribute(overloadable)
+__attribute__((__overloadable__))
+static inline const char *_Nullable __libroot_convert_path(char *_Nullable (*_Nonnull converter)(const char *_Nonnull, char *_Nullable), const char *_Nullable path, char *_Nonnull buf) {
+	return converter(path, buf);
+}
+#endif /* __has_attribute(overloadable) */
+
+#ifdef __OBJC__
+
+#import <Foundation/Foundation.h>
+
+#define __CONVERT_PATH_NSSTRING(converter, path) ({ \
+	char tmpBuf[PATH_MAX]; \
+	const char *converted = converter(path.fileSystemRepresentation, tmpBuf); \
+	converted ? [NSString stringWithUTF8String:converted] : nil; \
+})
+
+#define JBROOT_PATH_NSSTRING(path) __CONVERT_PATH_NSSTRING(libroot_dyn_jbrootpath, path)
+#define ROOTFS_PATH_NSSTRING(path) __CONVERT_PATH_NSSTRING(libroot_dyn_rootfspath, path)
+
+#if __has_attribute(overloadable)
+__attribute__((__overloadable__))
+static inline NSString *_Nullable __libroot_convert_path(char *_Nullable (*_Nonnull converter)(const char *_Nonnull, char *_Nullable), NSString *_Nullable path, void *_Nullable const __unused buf) {
+	return __CONVERT_PATH_NSSTRING(converter, path);
+}
+#endif /* __has_attribute(overloadable) */
+
+#endif /* __OBJC__ */
+
+#if __has_attribute(overloadable)
+
+#define __BUFFER_FOR_CHAR_P(x) \
+	__builtin_choose_expr(										\
+		__builtin_types_compatible_p(__typeof__(*(x)), char),	\
+		({ static char buf[PATH_MAX]; buf; }),					\
+		NULL													\
+	)
+
+#	define JBROOT_PATH(path) __libroot_convert_path(libroot_dyn_jbrootpath, (path), __BUFFER_FOR_CHAR_P(path))
+#	define ROOTFS_PATH(path) __libroot_convert_path(libroot_dyn_rootfspath, (path), __BUFFER_FOR_CHAR_P(path))
+#else
+#	define JBROOT_PATH(path) _Pragma("GCC error \"JBROOT_PATH is not supported with this compiler, use JBROOT_PATH_CSTRING or JBROOT_PATH_NSSTRING\"") path
+#	define ROOTFS_PATH(path) _Pragma("GCC error \"ROOTFS_PATH is not supported with this compiler, use ROOTFS_PATH_CSTRING or ROOTFS_PATH_NSSTRING\"") path
+#endif /* __has_attribute(overloadable) */
 
 #define JBRAND libroot_dyn_get_boot_uuid()


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

Update libroot to https://github.com/opa334/libroot/commit/102348f5e9360ad1f509ae4958bd3ca686347ee8

Checklist
---------
- [x] New code follows the [code rules](https://github.com/theos/headers/blob/master/README.md#code-rules)
- [x] I've added modulemaps for any new libraries (e.g. see [libactivator/module.modulemap](https://github.com/theos/headers/blob/f3e596d896bae8f07c43cfb00ef55bf6224b4cdc/libactivator/module.modulemap)): it should be possible to `@import MyLibrary;` in ObjC, or `import MyLibrary` in Swift.
- [x] My contribution is code written by myself from reverse-engineered headers, licensed into the Public Domain as per [LICENSE.md](LICENSE.md); or, code written by myself / taken from an existing project, released under an OSI-approved license, and I've added relevant licensing credit to [LICENSE.md](LICENSE.md)


Does this close any currently open issues?
------------------------------------------
No

Any relevant logs, error output, etc?
-------------------------------------
No

Any other comments?
-------------------
No

Where has this been tested?
---------------------------
**Operating System:** macOS

**Platform:** Darwin

**Target Platform:** iOS

**Toolchain Version:** `Apple clang version 15.0.0 (clang-1500.3.9.4)`

**SDK Version:** 16.5
