### PR TITLE
Provide definitions for macros in rootless.h when !TARGET_OS_IPHONE

### DIFF
--- a/rootless.h
+++ b/rootless.h
@@ -1,3 +1,7 @@
+#include <TargetConditionals.h>
+
+#if TARGET_OS_IPHONE
+
 #include <libroot/libroot.h>
 
 #ifdef XINA_SUPPORT
@@ -9,3 +13,23 @@ _Pragma("message(\"'XINA_SUPPORT' is deprecated. libroot will now handle this fo
 
 #define ROOT_PATH_NS(nsPath) JBROOT_PATH_NSSTRING(nsPath)
 #define ROOT_PATH_NS_VAR(nsPath) JBROOT_PATH_NSSTRING(nsPath)
+
+#else
+
+// no libroot support
+
+#include <sys/syslimits.h>
+#include <string.h>
+
+#define ROOT_PATH(cPath) THEOS_PACKAGE_INSTALL_PREFIX cPath
+#define ROOT_PATH_NS(path) @THEOS_PACKAGE_INSTALL_PREFIX path
+
+#define ROOT_PATH_NS_VAR(path) [@THEOS_PACKAGE_INSTALL_PREFIX stringByAppendingPathComponent:path]
+#define ROOT_PATH_VAR(path) sizeof(THEOS_PACKAGE_INSTALL_PREFIX) > 1 ? ({ \
+    char outPath[PATH_MAX]; \
+    strlcpy(outPath, THEOS_PACKAGE_INSTALL_PREFIX, PATH_MAX); \
+    strlcat(outPath, path, PATH_MAX); \
+    outPath; \
+}) : path
+
+#endif


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

Theos only links libroot when targeting `iphone`:
https://github.com/theos/theos/blob/351fbe83ee6058bdb64e90884c3bb047c31ab6c1/makefiles/instance/rules.mk#L139-L142

This is currently required because libroot is currently only compiled for iOS.

This PR seeks to match this linking behavior on the headers side:
Only include libroot if the target is iOS.

When libroot is not available, this PR uses the definitions that were previously used in a2a4086

I opted for this approach so that projects that target both iOS and macOS, in particular, can use macros from `rootless.h` without needing to shim these macros or provide separate code for each target.

Checklist
---------
- [x] New code follows the [code rules](https://github.com/theos/headers/blob/master/README.md#code-rules)
- [x] I've added modulemaps for any new libraries (e.g. see [libactivator/module.modulemap](https://github.com/theos/headers/blob/f3e596d896bae8f07c43cfb00ef55bf6224b4cdc/libactivator/module.modulemap)): it should be possible to `@import MyLibrary;` in ObjC, or `import MyLibrary` in Swift.
- [x] My contribution is code written by myself from reverse-engineered headers, licensed into the Public Domain as per [LICENSE.md](LICENSE.md); or, code written by myself / taken from an existing project, released under an OSI-approved license, and I've added relevant licensing credit to [LICENSE.md](LICENSE.md)


Does this close any currently open issues?
------------------------------------------

No

Any relevant logs, error output, etc?
-------------------------------------

Some tests:

`main.m`:

```objc
#import <Foundation/Foundation.h>
#import <rootless.h>

int main(int argc, const char *argv[]) {
	printf("ROOT_PATH: %s\n", ROOT_PATH("/bin/"));
	printf("ROOT_PATH_VAR: %s\n", ROOT_PATH_VAR(argv[0]));

	printf("ROOT_PATH_NS: %s\n", ROOT_PATH_NS(@"/bin/").UTF8String);
	printf("ROOT_PATH_NS_VAR: %s\n", ROOT_PATH_NS_VAR(@(argv[0])).UTF8String);

	return 0;
}
```

- Compiled for `TARGET="macosx:clang:latest:11.0"`
- Compiled for `TARGET="iphone:clang:latest:14.0"`

Any other comments?
-------------------

No

Where has this been tested?
---------------------------
**Operating System:** macOS

**Platform:** Darwin

**Target Platform:** iOS, macOS

**Toolchain Version:** `Apple clang version 15.0.0 (clang-1500.3.9.4)`

**SDK Version:** `MacOSX14.5.sdk`, `iPhoneOS17.5.sdk`
