### PR TITLE
[MobileCoreServices,MobileIcons] Add modulemap

### DIFF
--- a/MobileCoreServices/MobileCoreServices.h
+++ b/MobileCoreServices/MobileCoreServices.h
@@ -1,0 +1,11 @@
+#import <MobileCoreServices/LSAppLink.h>
+#import <MobileCoreServices/LSApplicationProxy.h>
+#import <MobileCoreServices/LSApplicationWorkspace.h>
+#import <MobileCoreServices/LSBundleProxy.h>
+#import <MobileCoreServices/LSDocumentProxy.h>
+#import <MobileCoreServices/LSOpenOperation.h>
+#import <MobileCoreServices/LSPlugInKitProxy.h>
+#import <MobileCoreServices/LSResourceProxy.h>
+#import <MobileCoreServices/NSString+LSAdditions.h>
+#import <MobileCoreServices/NSURL+LSAdditions.h>
+#import <MobileCoreServices/_LSQueryResult.h>

--- a/MobileCoreServices/module.modulemap
+++ b/MobileCoreServices/module.modulemap
@@ -1,0 +1,8 @@
+module MobileCoreServices {
+	umbrella header "MobileCoreServices.h"
+
+	link framework "MobileCoreServices"
+
+	export *
+	module * { export * }
+}

--- a/MobileIcons/module.modulemap
+++ b/MobileIcons/module.modulemap
@@ -1,0 +1,8 @@
+module MobileIcons {
+	umbrella header "MobileIcons.h"
+
+	link framework "MobileIcons"
+
+	export *
+	module * { export * }
+}


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

This enables https://github.com/hbang/libcephei/commit/7ad69a903cffa0b8240f8eb1a9afb27c15d8fe57 to compile.

This PR adds module information for
- `MobileCoreServices`
- `MobileIcons`

Checklist
---------
- [x] New code follows the [code rules](https://github.com/theos/headers/blob/master/README.md#code-rules)
- [x] I've added modulemaps for any new libraries (e.g. see [libactivator/module.modulemap](https://github.com/theos/headers/blob/f3e596d896bae8f07c43cfb00ef55bf6224b4cdc/libactivator/module.modulemap)): it should be possible to `@import MyLibrary;` in ObjC, or `import MyLibrary` in Swift.
- [x] My contribution is code written by myself from reverse-engineered headers, licensed into the Public Domain as per [LICENSE.md](LICENSE.md); or, code written by myself / taken from an existing project, released under an OSI-approved license, and I've added relevant licensing credit to [LICENSE.md](LICENSE.md)


Does this close any currently open issues?
------------------------------------------

https://github.com/hbang/libcephei/issues/58

Any relevant logs, error output, etc?
-------------------------------------

No

Any other comments?
-------------------

No

Where has this been tested?
---------------------------
**Operating System:** macOS

**Platform:** Darwin

**Target Platform:** iphone

**Toolchain Version:** `Apple clang version 15.0.0 (clang-1500.3.9.4)`

**SDK Version:** iPhoneOS16.5
