### PR TITLE
[rootless] Do not use libroot when targeting the simulator

### DIFF
--- a/rootless.h
+++ b/rootless.h
@@ -1,6 +1,6 @@
 #include <TargetConditionals.h>
 
-#if TARGET_OS_IPHONE
+#if TARGET_OS_IPHONE && !TARGET_OS_SIMULATOR
 
 #include <libroot/libroot.h>
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

libroot is not compiled for the simulator. 
To match this availability, use the fallback rootless macros when compiling for the simulator.

Checklist
---------
- [x] New code follows the [code rules](https://github.com/theos/headers/blob/master/README.md#code-rules)
- [x] I've added modulemaps for any new libraries (e.g. see [libactivator/module.modulemap](https://github.com/theos/headers/blob/f3e596d896bae8f07c43cfb00ef55bf6224b4cdc/libactivator/module.modulemap)): it should be possible to `@import MyLibrary;` in ObjC, or `import MyLibrary` in Swift.
- [x] My contribution is code written by myself from reverse-engineered headers, licensed into the Public Domain as per [LICENSE.md](LICENSE.md); or, code written by myself / taken from an existing project, released under an OSI-approved license, and I've added relevant licensing credit to [LICENSE.md](LICENSE.md)


Does this close any currently open issues?
------------------------------------------

No

Any relevant logs, error output, etc?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------

No

Where has this been tested?
---------------------------
**Operating System:** macOS 15.3

**Platform:** Darwin

**Target Platform:** iphone, simulator

**Toolchain Version:** `Apple clang version 16.0.0 (clang-1600.0.26.6)`

**SDK Version:** `18.2`
