### PR TITLE
[UIKit] Create UIImageAsset+Private.h

### DIFF
--- a/UIKit/UIImageAsset+Private.h
+++ b/UIKit/UIImageAsset+Private.h
@@ -1,0 +1,7 @@
+#import <UIKit/UIImageAsset.h>
+
+@interface UIImageAsset (Private)
+
+@property (nonatomic, copy) NSString *assetName;
+
+@end


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link below to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------

Add `UIImageAsset+Private.h` header.

Checklist
---------
- [ ] New code follows the [code rules](https://github.com/theos/headers/blob/master/README.md#code-rules)
- [ ] I've added modulemaps for any new libraries (e.g. see [libactivator/module.modulemap](https://github.com/theos/headers/blob/f3e596d896bae8f07c43cfb00ef55bf6224b4cdc/libactivator/module.modulemap)): it should be possible to `@import MyLibrary;` in ObjC, or `import MyLibrary` in Swift.
- [ ] My contribution is code written by myself from reverse-engineered headers, licensed into the Public Domain as per [LICENSE.md](LICENSE.md); or, code written by myself / taken from an existing project, released under an OSI-approved license, and I've added relevant licensing credit to [LICENSE.md](LICENSE.md)


Does this close any currently open issues?
------------------------------------------
…

Any relevant logs, error output, etc?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
**Operating System:** …

**Platform:** …

**Target Platform:** …

**Toolchain Version:** …

**SDK Version:** …
