### PR TITLE
Fix return value of entitlements & ambiguous initializers

### DIFF
--- a/MobileCoreServices/LSApplicationProxy.h
+++ b/MobileCoreServices/LSApplicationProxy.h
@@ -5,7 +5,7 @@
 API_AVAILABLE(ios(4.0))
 @interface LSApplicationProxy : LSBundleProxy
 
-+ (instancetype)applicationProxyForIdentifier:(NSString *)identifier;
++ (instancetype)applicationProxyForIdentifier:(NSString *)identifier NS_SWIFT_NAME(applicationProxy(forIdentifier:));
 
 @property (nonatomic, readonly) NSString *applicationIdentifier;
 @property (nonatomic, readonly) NSString *vendorName   API_AVAILABLE(ios(7.0));

--- a/MobileCoreServices/LSBundleProxy.h
+++ b/MobileCoreServices/LSBundleProxy.h
@@ -4,7 +4,7 @@ API_AVAILABLE(ios(8.0))
 @interface LSBundleProxy : LSResourceProxy
 
 + (instancetype)bundleProxyForCurrentProcess API_AVAILABLE(ios(10.0));
-+ (instancetype)bundleProxyForIdentifier:(NSString *)identifier;
++ (instancetype)bundleProxyForIdentifier:(NSString *)identifier NS_SWIFT_NAME(bundleProxy(forIdentifier:));
 + (instancetype)bundleProxyForURL:(NSURL *)url;
 
 @property (nonatomic, readonly) NSUUID *cacheGUID;
@@ -20,7 +20,7 @@ API_AVAILABLE(ios(8.0))
 @property (nonatomic, readonly) NSString *bundleType;
 @property (nonatomic, readonly) NSString *canonicalExecutablePath API_AVAILABLE(ios(10.3));
 
-@property (nonatomic, readonly) NSDictionary <NSString *, NSString *> *entitlements;
+@property (nonatomic, readonly) NSDictionary <NSString *, id> *entitlements;
 @property (nonatomic, readonly) NSDictionary <NSString *, NSString *> *environmentVariables;
 @property (nonatomic, readonly) NSDictionary <NSString *, NSURL *> *groupContainerURLs;
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link below to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------

**Problems**:

1. The type of value `-entitlements` should be `NSDictionary <NSString *, id> *` or simply written as `NSDictionary *`, not `NSDictionary <NSString *, NSString *> *`. Which causes conflict when access non-string values in Swift.
2. Initializers of `LSApplicationProxy` and `LSBundleProxy` are treated as the same in Swift: `init(forIdentifier:)`. Which was ambiguous and caused error below (there’s no other way to call these methods in Swift):

**Fixes**:

1. Change return type of `-entitlements` to `NSDictionary <NSString *, id> *`.
2. Use macro `NS_SWIFT_NAME` to make explicit method signatures of these initializers.

**Before**:

![image](https://github.com/user-attachments/assets/cc8510d1-08b6-4ed1-bd81-29e7f7488be5)

**After**:

![image](https://github.com/user-attachments/assets/f5630d47-fc3f-41f6-bd11-6bc040cc44b9)

Checklist
---------
- [x] New code follows the [code rules](https://github.com/theos/headers/blob/master/README.md#code-rules)
- [x] I've added modulemaps for any new libraries (e.g. see [libactivator/module.modulemap](https://github.com/theos/headers/blob/f3e596d896bae8f07c43cfb00ef55bf6224b4cdc/libactivator/module.modulemap)): it should be possible to `@import MyLibrary;` in ObjC, or `import MyLibrary` in Swift.
- [x] My contribution is code written by myself from reverse-engineered headers, licensed into the Public Domain as per [LICENSE.md](LICENSE.md); or, code written by myself / taken from an existing project, released under an OSI-approved license, and I've added relevant licensing credit to [LICENSE.md](LICENSE.md)


Does this close any currently open issues?
------------------------------------------
No.

Any relevant logs, error output, etc?
-------------------------------------
See screenshots above.

Any other comments?
-------------------
No.

Where has this been tested?
---------------------------
**Operating System:** macOS 15.3.2

**Platform:** macOS

**Target Platform:** iOS

**Toolchain Version:** Xcode 16.2

**SDK Version:** iOS 18.2
